### PR TITLE
refactor(capacitorCalendarPlugin.kt): remove useless result variables

### DIFF
--- a/android/src/main/java/dev/barooni/capacitor/calendar/CapacitorCalendarPlugin.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/CapacitorCalendarPlugin.kt
@@ -208,7 +208,6 @@ class CapacitorCalendarPlugin : Plugin() {
     @ActivityCallback
     private fun createEventWithPromptCallback(
         call: PluginCall?,
-        result: ActivityResult,
     ) {
         if (call == null) {
             return
@@ -229,7 +228,6 @@ class CapacitorCalendarPlugin : Plugin() {
     @ActivityCallback
     private fun modifyEventWithPromptCallback(
         call: PluginCall?,
-        result: ActivityResult,
     ) {
         if (call == null) {
             return


### PR DESCRIPTION
## Description
Remove the unused `result: activityResult` variables from 
- createEventWIthPromptCallback
- modifyEventWithPromptCallback

Fixes : https://github.com/ebarooni/capacitor-calendar/issues/198