### PR TITLE
feat(android): return event ID from createEventWithPrompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,48 +219,48 @@ See [CHANGELOG.md](CHANGELOG.md) for the latest updates and release history.
 
 <docgen-index>
 
-- [`checkPermission(...)`](#checkpermission)
-- [`checkAllPermissions()`](#checkallpermissions)
-- [`requestPermission(...)`](#requestpermission)
-- [`requestAllPermissions()`](#requestallpermissions)
-- [`requestWriteOnlyCalendarAccess()`](#requestwriteonlycalendaraccess)
-- [`requestReadOnlyCalendarAccess()`](#requestreadonlycalendaraccess)
-- [`requestFullCalendarAccess()`](#requestfullcalendaraccess)
-- [`requestFullRemindersAccess()`](#requestfullremindersaccess)
-- [`createEventWithPrompt(...)`](#createeventwithprompt)
-- [`modifyEventWithPrompt(...)`](#modifyeventwithprompt)
-- [`createEvent(...)`](#createevent)
-- [`modifyEvent(...)`](#modifyevent)
-- [`deleteEventsById(...)`](#deleteeventsbyid)
-- [`deleteEvent(...)`](#deleteevent)
-- [`deleteEventWithPrompt(...)`](#deleteeventwithprompt)
-- [`listEventsInRange(...)`](#listeventsinrange)
-- [`commit()`](#commit)
-- [`selectCalendarsWithPrompt(...)`](#selectcalendarswithprompt)
-- [`fetchAllCalendarSources()`](#fetchallcalendarsources)
-- [`listCalendars()`](#listcalendars)
-- [`getDefaultCalendar()`](#getdefaultcalendar)
-- [`openCalendar(...)`](#opencalendar)
-- [`createCalendar(...)`](#createcalendar)
-- [`deleteCalendar(...)`](#deletecalendar)
-- [`modifyCalendar(...)`](#modifycalendar)
-- [`createRemindersList(...)`](#createreminderslist)
-- [`deleteRemindersList(...)`](#deletereminderslist)
-- [`fetchAllRemindersSources()`](#fetchallreminderssources)
-- [`openReminders()`](#openreminders)
-- [`getDefaultRemindersList()`](#getdefaultreminderslist)
-- [`getRemindersLists()`](#getreminderslists)
-- [`createReminder(...)`](#createreminder)
-- [`deleteRemindersById(...)`](#deleteremindersbyid)
-- [`deleteReminder(...)`](#deletereminder)
-- [`modifyReminder(...)`](#modifyreminder)
-- [`getReminderById(...)`](#getreminderbyid)
-- [`getRemindersFromLists(...)`](#getremindersfromlists)
-- [`deleteReminderWithPrompt(...)`](#deletereminderwithprompt)
-- [`updateRemindersList(...)`](#updatereminderslist)
-- [Interfaces](#interfaces)
-- [Type Aliases](#type-aliases)
-- [Enums](#enums)
+* [`checkPermission(...)`](#checkpermission)
+* [`checkAllPermissions()`](#checkallpermissions)
+* [`requestPermission(...)`](#requestpermission)
+* [`requestAllPermissions()`](#requestallpermissions)
+* [`requestWriteOnlyCalendarAccess()`](#requestwriteonlycalendaraccess)
+* [`requestReadOnlyCalendarAccess()`](#requestreadonlycalendaraccess)
+* [`requestFullCalendarAccess()`](#requestfullcalendaraccess)
+* [`requestFullRemindersAccess()`](#requestfullremindersaccess)
+* [`createEventWithPrompt(...)`](#createeventwithprompt)
+* [`modifyEventWithPrompt(...)`](#modifyeventwithprompt)
+* [`createEvent(...)`](#createevent)
+* [`modifyEvent(...)`](#modifyevent)
+* [`deleteEventsById(...)`](#deleteeventsbyid)
+* [`deleteEvent(...)`](#deleteevent)
+* [`deleteEventWithPrompt(...)`](#deleteeventwithprompt)
+* [`listEventsInRange(...)`](#listeventsinrange)
+* [`commit()`](#commit)
+* [`selectCalendarsWithPrompt(...)`](#selectcalendarswithprompt)
+* [`fetchAllCalendarSources()`](#fetchallcalendarsources)
+* [`listCalendars()`](#listcalendars)
+* [`getDefaultCalendar()`](#getdefaultcalendar)
+* [`openCalendar(...)`](#opencalendar)
+* [`createCalendar(...)`](#createcalendar)
+* [`deleteCalendar(...)`](#deletecalendar)
+* [`modifyCalendar(...)`](#modifycalendar)
+* [`createRemindersList(...)`](#createreminderslist)
+* [`deleteRemindersList(...)`](#deletereminderslist)
+* [`fetchAllRemindersSources()`](#fetchallreminderssources)
+* [`openReminders()`](#openreminders)
+* [`getDefaultRemindersList()`](#getdefaultreminderslist)
+* [`getRemindersLists()`](#getreminderslists)
+* [`createReminder(...)`](#createreminder)
+* [`deleteRemindersById(...)`](#deleteremindersbyid)
+* [`deleteReminder(...)`](#deletereminder)
+* [`modifyReminder(...)`](#modifyreminder)
+* [`getReminderById(...)`](#getreminderbyid)
+* [`getRemindersFromLists(...)`](#getremindersfromlists)
+* [`deleteReminderWithPrompt(...)`](#deletereminderwithprompt)
+* [`updateRemindersList(...)`](#updatereminderslist)
+* [Interfaces](#interfaces)
+* [Type Aliases](#type-aliases)
+* [Enums](#enums)
 
 </docgen-index>
 
@@ -285,7 +285,8 @@ Retrieves the current permission state for a given scope.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### checkAllPermissions()
 
@@ -301,7 +302,8 @@ Retrieves the current state of all permissions.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### requestPermission(...)
 
@@ -321,7 +323,8 @@ Requests permission for a given scope.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### requestAllPermissions()
 
@@ -337,7 +340,8 @@ Requests permission for all calendar and reminder permissions.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### requestWriteOnlyCalendarAccess()
 
@@ -353,7 +357,8 @@ Requests write access to the calendar.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### requestReadOnlyCalendarAccess()
 
@@ -369,7 +374,8 @@ Requests read access to the calendar.
 
 **Platform:** Android
 
----
+--------------------
+
 
 ### requestFullCalendarAccess()
 
@@ -385,7 +391,8 @@ Requests read and write access to the calendar.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### requestFullRemindersAccess()
 
@@ -401,7 +408,8 @@ Requests read and write access to the reminders.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### createEventWithPrompt(...)
 
@@ -410,8 +418,13 @@ createEventWithPrompt(options?: CreateEventWithPromptOptions | undefined) => Pro
 ```
 
 Opens the system calendar interface to create a new event.
-On Android always returns `null`.
-Fetch the events to find the ID of the newly created event.
+Returns the ID of the newly created event on both platforms.
+
+On iOS, the ID is retrieved directly from the event edit controller.
+On Android, the ID is retrieved by querying the calendar provider after
+the native UI returns. This requires `READ_CALENDAR` permission to be
+granted; if not available, `null` is returned. The ID may also be `null`
+if the user cancels or if the newly created event cannot be matched.
 
 | Param         | Type                                                                                  |
 | ------------- | ------------------------------------------------------------------------------------- |
@@ -423,7 +436,8 @@ Fetch the events to find the ID of the newly created event.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### modifyEventWithPrompt(...)
 
@@ -444,7 +458,8 @@ On Android always returns `null`.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### createEvent(...)
 
@@ -464,7 +479,8 @@ Creates an event in the calendar.
 
 **Platform:** iOS, Android
 
----
+--------------------
+
 
 ### modifyEvent(...)
 
@@ -482,7 +498,8 @@ Modifies an event.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### deleteEventsById(...)
 
@@ -502,7 +519,8 @@ Deletes multiple events.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### deleteEvent(...)
 
@@ -520,7 +538,8 @@ Deletes an event.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### deleteEventWithPrompt(...)
 
@@ -540,7 +559,8 @@ Opens a dialog to delete an event.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### listEventsInRange(...)
 
@@ -560,7 +580,8 @@ Retrieves the events within a date range.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### commit()
 
@@ -574,7 +595,8 @@ Save the changes to the calendar.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### selectCalendarsWithPrompt(...)
 
@@ -594,7 +616,8 @@ Opens a system interface to choose one or multiple calendars.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### fetchAllCalendarSources()
 
@@ -610,7 +633,8 @@ Retrieves a list of calendar sources.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### listCalendars()
 
@@ -626,7 +650,8 @@ Retrieves a list of all available calendars.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### getDefaultCalendar()
 
@@ -642,7 +667,8 @@ Retrieves the default calendar.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### openCalendar(...)
 
@@ -660,7 +686,8 @@ Opens the calendar app.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### createCalendar(...)
 
@@ -680,7 +707,8 @@ Creates a calendar.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### deleteCalendar(...)
 
@@ -698,7 +726,8 @@ Deletes a calendar by id.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### modifyCalendar(...)
 
@@ -716,7 +745,8 @@ Modifies a calendar with options.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### createRemindersList(...)
 
@@ -736,7 +766,8 @@ Creates a new reminders list.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### deleteRemindersList(...)
 
@@ -754,7 +785,8 @@ Deletes a reminders list.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### fetchAllRemindersSources()
 
@@ -770,7 +802,8 @@ Retrieves a list of calendar sources.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### openReminders()
 
@@ -784,7 +817,8 @@ Opens the reminders app.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### getDefaultRemindersList()
 
@@ -800,7 +834,8 @@ Retrieves the default reminders list.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### getRemindersLists()
 
@@ -816,7 +851,8 @@ Retrieves all available reminders lists.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### createReminder(...)
 
@@ -836,7 +872,8 @@ Creates a reminder.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### deleteRemindersById(...)
 
@@ -856,7 +893,8 @@ Deletes multiple reminders.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### deleteReminder(...)
 
@@ -874,7 +912,8 @@ Deletes a reminder.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### modifyReminder(...)
 
@@ -892,7 +931,8 @@ Modifies a reminder.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### getReminderById(...)
 
@@ -912,7 +952,8 @@ Retrieve a reminder by ID.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### getRemindersFromLists(...)
 
@@ -932,7 +973,8 @@ Retrieves reminders from multiple lists.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### deleteReminderWithPrompt(...)
 
@@ -952,7 +994,8 @@ Opens a dialog to delete a reminder.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### updateRemindersList(...)
 
@@ -972,9 +1015,11 @@ Update a reminders list with options.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### Interfaces
+
 
 #### CreateEventWithPromptOptions
 
@@ -993,6 +1038,7 @@ Update a reminders list with options.
 | **`title`**        | <code>string</code>                                                 |                                                                                                                                                                                                  | 0.1.0 | Android, iOS |
 | **`url`**          | <code>string</code>                                                 |                                                                                                                                                                                                  | 0.1.0 | iOS          |
 
+
 #### EventRecurrenceRule
 
 | Prop                 | Type                                                                | Description                                                                                                                                                             | Default        | Since | Platform     |
@@ -1006,6 +1052,7 @@ Update a reminders list with options.
 | **`frequency`**      | <code><a href="#recurrencefrequency">RecurrenceFrequency</a></code> | How often the event repeats.                                                                                                                                            |                | 7.3.0 | Android, iOS |
 | **`interval`**       | <code>number</code>                                                 | The interval between recurrences. Use in combination with `frequency`. For example, a weekly event with an interval of 2, results in the event occurring every 2 weeks. | <code>1</code> | 7.3.0 | Android, iOS |
 | **`weeksOfTheYear`** | <code>number[]</code>                                               | Limits a yearly recurrence to specific ISO week numbers (1 to 53).                                                                                                      |                | 7.3.0 | iOS          |
+
 
 #### ModifyEventWithPromptOptions
 
@@ -1024,6 +1071,7 @@ Update a reminders list with options.
 | **`title`**        | <code>string</code>                                                 |                                                                                                                                                                                                  | 0.1.0 | Android, iOS |
 | **`url`**          | <code>string</code>                                                 |                                                                                                                                                                                                  | 0.1.0 | iOS          |
 | **`id`**           | <code>string</code>                                                 | The ID of the event to be modified.                                                                                                                                                              | 7.1.0 | Android, iOS |
+
 
 #### CreateEventOptions
 
@@ -1046,12 +1094,14 @@ Update a reminders list with options.
 | **`title`**        | <code>string</code>                                                 |                                                                                                                                                        |                   | 0.4.0 | Android, iOS |
 | **`url`**          | <code>string</code>                                                 |                                                                                                                                                        |                   | 0.1.0 | iOS          |
 
+
 #### EventGuest
 
 | Prop        | Type                | Since |
 | ----------- | ------------------- | ----- |
 | **`name`**  | <code>string</code> | 7.1.0 |
 | **`email`** | <code>string</code> | 7.1.0 |
+
 
 #### ModifyEventOptions
 
@@ -1075,12 +1125,14 @@ Update a reminders list with options.
 | **`title`**        | <code>string</code>                                                 |                                                                                                                                                        |                                   | 0.4.0 | Android, iOS |
 | **`url`**          | <code>string</code>                                                 |                                                                                                                                                        |                                   | 0.1.0 | iOS          |
 
+
 #### DeleteEventsByIdResult
 
 | Prop          | Type                  | Since |
 | ------------- | --------------------- | ----- |
 | **`deleted`** | <code>string[]</code> | 7.1.0 |
 | **`failed`**  | <code>string[]</code> | 7.1.0 |
+
 
 #### DeleteEventsByIdOptions
 
@@ -1089,12 +1141,14 @@ Update a reminders list with options.
 | **`ids`**  | <code>string[]</code>                           |                       |                                   | 7.1.0 |          |
 | **`span`** | <code><a href="#eventspan">EventSpan</a></code> | The span of deletion. | <code>EventSpan.THIS_EVENT</code> |       | iOS      |
 
+
 #### DeleteEventOptions
 
 | Prop       | Type                                            | Description           | Default                           | Since | Platform |
 | ---------- | ----------------------------------------------- | --------------------- | --------------------------------- | ----- | -------- |
 | **`id`**   | <code>string</code>                             |                       |                                   | 7.1.0 |          |
 | **`span`** | <code><a href="#eventspan">EventSpan</a></code> | The span of deletion. | <code>EventSpan.THIS_EVENT</code> |       | iOS      |
+
 
 #### DeleteEventWithPromptOptions
 
@@ -1106,6 +1160,7 @@ Update a reminders list with options.
 | **`message`**           | <code>string</code>                             | Message of the dialog.              |                                   | 7.1.0 | Android, iOS |
 | **`confirmButtonText`** | <code>string</code>                             | Text to show on the confirm button. | <code>'Delete'</code>             | 7.1.0 | Android, iOS |
 | **`cancelButtonText`**  | <code>string</code>                             | Text to show on the cancel button.  | <code>'Cancel'</code>             | 7.1.0 | Android, iOS |
+
 
 #### CalendarEvent
 
@@ -1133,12 +1188,14 @@ Update a reminders list with options.
 | **`attendees`**                 | <code>{ email: string \| null; name: string \| null; role: <a href="#attendeerole">AttendeeRole</a> \| null; status: <a href="#attendeestatus">AttendeeStatus</a> \| null; type: <a href="#attendeetype">AttendeeType</a> \| null; }[]</code> |                                                     | 7.1.0 | Android, iOS |
 | **`timezone`**                  | <code>string \| null</code>                                                                                                                                                                                                                   |                                                     | 7.1.0 | Android, iOS |
 
+
 #### ListEventsInRangeOptions
 
 | Prop       | Type                | Description                    | Since |
 | ---------- | ------------------- | ------------------------------ | ----- |
 | **`from`** | <code>number</code> | The timestamp in milliseconds. | 7.1.0 |
 | **`to`**   | <code>number</code> | The timestamp in milliseconds. | 7.1.0 |
+
 
 #### Calendar
 
@@ -1159,6 +1216,7 @@ Update a reminders list with options.
 | **`maxReminders`**               | <code>number \| null</code>                                       | Maximum number of reminders allowed per event.                     | 7.1.0 | Android      |
 | **`location`**                   | <code>string \| null</code>                                       |                                                                    | 7.1.0 | Android      |
 
+
 #### CalendarSource
 
 | Prop        | Type                                                              | Since |
@@ -1167,6 +1225,7 @@ Update a reminders list with options.
 | **`id`**    | <code>string</code>                                               | 7.1.0 |
 | **`title`** | <code>string</code>                                               | 7.1.0 |
 
+
 #### SelectCalendarsWithPromptOptions
 
 | Prop               | Type                                                                                | Description                | Default                                                | Since |
@@ -1174,11 +1233,13 @@ Update a reminders list with options.
 | **`displayStyle`** | <code><a href="#calendarchooserdisplaystyle">CalendarChooserDisplayStyle</a></code> |                            | <code>CalendarChooserDisplayStyle.ALL_CALENDARS</code> | 7.1.0 |
 | **`multiple`**     | <code>boolean</code>                                                                | Allow multiple selections. | <code>false</code>                                     | 7.1.0 |
 
+
 #### OpenCalendarOptions
 
 | Prop       | Type                | Default                 | Since |
 | ---------- | ------------------- | ----------------------- | ----- |
 | **`date`** | <code>number</code> | <code>Date.now()</code> | 7.1.0 |
+
 
 #### CreateCalendarOptions
 
@@ -1190,11 +1251,13 @@ Update a reminders list with options.
 | **`accountName`**  | <code>string</code> | Only needed on Android. Typically set to an email address. | 7.1.0 | Android      |
 | **`ownerAccount`** | <code>string</code> | Only needed on Android. Typically set to an email address. | 7.1.0 | Android      |
 
+
 #### DeleteCalendarOptions
 
 | Prop     | Type                | Since |
 | -------- | ------------------- | ----- |
 | **`id`** | <code>string</code> | 7.1.0 |
+
 
 #### ModifyCalendarOptions
 
@@ -1204,11 +1267,13 @@ Update a reminders list with options.
 | **`title`** | <code>string</code> | 7.2.0 | Android, iOS |
 | **`color`** | <code>string</code> | 7.2.0 | Android, iOS |
 
+
 #### CreateRemindersListResult
 
 | Prop     | Type                | Description                                     | Since | Platform |
 | -------- | ------------------- | ----------------------------------------------- | ----- | -------- |
 | **`id`** | <code>string</code> | Identifier of the newly created reminders list. | 8.1.0 | iOS      |
+
 
 #### CreateRemindersListOptions
 
@@ -1219,12 +1284,14 @@ Update a reminders list with options.
 | **`sourceId`** | <code>string</code>                                                                                                              | The EKSource identifier (account) where the list should be created. If left undefined, iCloud will be used if available, otherwise falls back to local.                                                                      |                     | 8.1.0 | iOS      |
 | **`title`**    | <code>string</code>                                                                                                              | The title of the list.                                                                                                                                                                                                       |                     | 8.1.0 | iOS      |
 
+
 #### DeleteRemindersListOptions
 
 | Prop         | Type                 | Description                                                                                                                                                                                                                      | Default           | Since | Platform |
 | ------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | ----- | -------- |
 | **`commit`** | <code>boolean</code> | Whether to save the deletion to the event store immediately. Pass `false` to batch multiple changes and commit them together using `CapacitorCalendar.commit()`, which is more efficient than committing each save individually. | <code>true</code> | 8.2.0 | iOS      |
 | **`id`**     | <code>string</code>  | Identifier of the reminders list to delete.                                                                                                                                                                                      |                   | 8.2.0 | iOS      |
+
 
 #### CreateReminderOptions
 
@@ -1243,6 +1310,7 @@ Update a reminders list with options.
 | **`recurrence`**     | <code><a href="#recurrencerule">RecurrenceRule</a></code> |                                                                                                                                                           | 7.1.0 |
 | **`alerts`**         | <code>number[]</code>                                     | Alert times in minutes relative to the reminder start. Use negative numbers for alerts before the start, and positive numbers for alerts after the start. | 7.1.0 |
 
+
 #### RecurrenceRule
 
 | Prop            | Type                                                                | Description                                                                        | Since |
@@ -1251,6 +1319,7 @@ Update a reminders list with options.
 | **`interval`**  | <code>number</code>                                                 | How often it repeats (e.g. 1 for every occurrence, 2 for every second occurrence). | 7.1.0 |
 | **`end`**       | <code>number</code>                                                 | Timestamp of when the recurrence ends.                                             | 7.1.0 |
 
+
 #### DeleteRemindersByIdResult
 
 | Prop          | Type                  | Since |
@@ -1258,17 +1327,20 @@ Update a reminders list with options.
 | **`deleted`** | <code>string[]</code> | 7.1.0 |
 | **`failed`**  | <code>string[]</code> | 7.1.0 |
 
+
 #### DeleteRemindersByIdOptions
 
 | Prop      | Type                  | Since |
 | --------- | --------------------- | ----- |
 | **`ids`** | <code>string[]</code> | 7.1.0 |
 
+
 #### DeleteReminderOptions
 
 | Prop     | Type                | Since |
 | -------- | ------------------- | ----- |
 | **`id`** | <code>string</code> | 7.1.0 |
+
 
 #### ModifyReminderOptions
 
@@ -1288,6 +1360,7 @@ Update a reminders list with options.
 | **`recurrence`**     | <code><a href="#recurrencerule">RecurrenceRule</a></code> |                                                                                                                                                                                               | 7.1.0 |
 | **`alerts`**         | <code>number[]</code>                                     | Alert times in minutes relative to the reminder start. Use negative numbers for alerts before the start, and positive numbers for alerts after the start. On iOS only 2 alerts are supported. | 7.1.0 |
 
+
 #### Reminder
 
 | Prop                 | Type                          | Since |
@@ -1306,17 +1379,20 @@ Update a reminders list with options.
 | **`recurrence`**     | <code>RecurrenceRule[]</code> | 7.1.0 |
 | **`alerts`**         | <code>number[]</code>         | 7.1.0 |
 
+
 #### GetReminderByIdOptions
 
 | Prop     | Type                | Since |
 | -------- | ------------------- | ----- |
 | **`id`** | <code>string</code> | 7.1.0 |
 
+
 #### GetRemindersFromListsOptions
 
 | Prop          | Type                  | Since |
 | ------------- | --------------------- | ----- |
 | **`listIds`** | <code>string[]</code> | 7.1.0 |
+
 
 #### DeleteReminderWithPromptOptions
 
@@ -1328,11 +1404,13 @@ Update a reminders list with options.
 | **`confirmButtonText`** | <code>string</code> | Text to show on the confirm button. | <code>'Delete'</code> | 7.2.0 |
 | **`cancelButtonText`**  | <code>string</code> | Text to show on the cancel button.  | <code>'Cancel'</code> | 7.2.0 |
 
+
 #### UpdateRemindersListResult
 
 | Prop     | Type                | Description                               | Since | Platform |
 | -------- | ------------------- | ----------------------------------------- | ----- | -------- |
 | **`id`** | <code>string</code> | Identifier of the updated reminders list. | 8.2.0 | iOS      |
+
 
 #### UpdateRemindersListOptions
 
@@ -1343,48 +1421,49 @@ Update a reminders list with options.
 | **`id`**     | <code>string</code>                                                                                                              | The identifier of the list to update.                                                                                                                                                                                   |                   | 8.2.0 | iOS      |
 | **`title`**  | <code>string</code>                                                                                                              | The new title of the list. If omitted, the title is left unchanged.                                                                                                                                                     |                   | 8.2.0 | iOS      |
 
+
 ### Type Aliases
+
 
 #### PermissionState
 
 <code>'prompt' | 'prompt-with-rationale' | 'granted' | 'denied'</code>
 
+
 #### CheckAllPermissionsResult
 
-<code>
-  <a href="#record">Record</a>&lt;<a href="#calendarpermissionscope">CalendarPermissionScope</a>,{' '}
-  <a href="#permissionstate">PermissionState</a>&gt;
-</code>
+<code><a href="#record">Record</a>&lt;<a href="#calendarpermissionscope">CalendarPermissionScope</a>, <a href="#permissionstate">PermissionState</a>&gt;</code>
+
 
 #### Record
 
 Construct a type with a set of properties K of type T
 
-<code>{
- [P in K]: T;
- }</code>
+<code>{ [P in K]: T; }</code>
+
 
 #### RequestAllPermissionsResult
 
-<code>
-  <a href="#checkallpermissionsresult">CheckAllPermissionsResult</a>
-</code>
+<code><a href="#checkallpermissionsresult">CheckAllPermissionsResult</a></code>
+
 
 #### RecurrenceFrequency
 
 <code>'daily' | 'weekly' | 'monthly' | 'yearly'</code>
 
+
 #### EventEditAction
 
 <code>'canceled' | 'saved' | 'deleted'</code>
 
+
 #### RemindersList
 
-<code>
-  <a href="#calendar">Calendar</a>
-</code>
+<code><a href="#calendar">Calendar</a></code>
+
 
 ### Enums
+
 
 #### CalendarPermissionScope
 
@@ -1394,6 +1473,7 @@ Construct a type with a set of properties K of type T
 | **`READ_REMINDERS`**  | <code>'readReminders'</code>  | Permission required for reading reminders.                   | 7.1.0 | iOS          |
 | **`WRITE_CALENDAR`**  | <code>'writeCalendar'</code>  | Permission required for adding or modifying calendar events. | 7.1.0 | Android, iOS |
 | **`WRITE_REMINDERS`** | <code>'writeReminders'</code> | Permission required for adding or modifying reminders.       | 7.1.0 | iOS          |
+
 
 #### EventAvailability
 
@@ -1405,12 +1485,14 @@ Construct a type with a set of properties K of type T
 | **`TENTATIVE`**     |                 | 7.1.0 | Android, iOS |
 | **`UNAVAILABLE`**   |                 | 7.1.0 | iOS          |
 
+
 #### EventSpan
 
 | Members                      | Since |
 | ---------------------------- | ----- |
 | **`THIS_EVENT`**             | 7.1.0 |
 | **`THIS_AND_FUTURE_EVENTS`** | 7.1.0 |
+
 
 #### EventStatus
 
@@ -1420,6 +1502,7 @@ Construct a type with a set of properties K of type T
 | **`CONFIRMED`** | <code>'confirmed'</code> | 7.1.0 | Android, iOS |
 | **`TENTATIVE`** | <code>'tentative'</code> | 7.1.0 | Android, iOS |
 | **`CANCELED`**  | <code>'canceled'</code>  | 7.1.0 | Android, iOS |
+
 
 #### AttendeeRole
 
@@ -1434,6 +1517,7 @@ Construct a type with a set of properties K of type T
 | **`ORGANIZER`**       | <code>'organizer'</code>      | 7.1.0 | Android      |
 | **`PERFORMER`**       | <code>'performer'</code>      | 7.1.0 | Android      |
 | **`SPEAKER`**         | <code>'speaker'</code>        | 7.1.0 | Android      |
+
 
 #### AttendeeStatus
 
@@ -1450,6 +1534,7 @@ Construct a type with a set of properties K of type T
 | **`COMPLETED`**  | <code>'completed'</code> | 7.1.0 | iOS          |
 | **`IN_PROCESS`** | <code>'inProcess'</code> | 7.1.0 | iOS          |
 
+
 #### AttendeeType
 
 | Members        | Value                   | Since | Platform     |
@@ -1463,6 +1548,7 @@ Construct a type with a set of properties K of type T
 | **`NONE`**     | <code>'none'</code>     | 7.1.0 | Android      |
 | **`OPTIONAL`** | <code>'optional'</code> | 7.1.0 | Android      |
 
+
 #### CalendarType
 
 | Members            | Since |
@@ -1472,6 +1558,7 @@ Construct a type with a set of properties K of type T
 | **`EXCHANGE`**     | 7.1.0 |
 | **`SUBSCRIPTION`** | 7.1.0 |
 | **`BIRTHDAY`**     | 7.1.0 |
+
 
 #### CalendarSourceType
 
@@ -1483,6 +1570,7 @@ Construct a type with a set of properties K of type T
 | **`MOBILE_ME`**  | 7.1.0 |
 | **`SUBSCRIBED`** | 7.1.0 |
 | **`BIRTHDAYS`**  | 7.1.0 |
+
 
 #### CalendarChooserDisplayStyle
 

--- a/android/src/main/java/dev/barooni/capacitor/calendar/CapacitorCalendarPlugin.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/CapacitorCalendarPlugin.kt
@@ -61,7 +61,6 @@ class CapacitorCalendarPlugin : Plugin() {
     private var prePromptEventIds: Set<Long> = emptySet()
     private var promptTitle: String? = null
     private var promptStartDate: Long? = null
-    private var promptEndDate: Long? = null
 
     @PluginMethod
     fun checkPermission(call: PluginCall) {
@@ -215,7 +214,6 @@ class CapacitorCalendarPlugin : Plugin() {
             val input = CreateEventWithPromptInput(call, "createEventWithPromptCallback")
             promptTitle = input.title.ifEmpty { null }
             promptStartDate = input.startDate
-            promptEndDate = input.endDate
             prePromptEventIds = snapshotMatchingEventIds()
             implementation.createEventWithPrompt(input, ::startActivityForResult)
         } catch (error: Exception) {
@@ -473,14 +471,14 @@ class CapacitorCalendarPlugin : Plugin() {
         return try {
             val cr = context.contentResolver
             val titleIds =
-                if (promptTitle != null || promptStartDate != null || promptEndDate != null) {
-                    ImplementationHelper.findMatchingEventIds(cr, promptTitle, promptStartDate, promptEndDate)
+                if (promptTitle != null || promptStartDate != null) {
+                    ImplementationHelper.findMatchingEventIds(cr, promptTitle, promptStartDate)
                 } else {
                     emptySet()
                 }
             val timeOnlyIds =
-                if (promptTitle != null && (promptStartDate != null || promptEndDate != null)) {
-                    ImplementationHelper.findMatchingEventIds(cr, null, promptStartDate, promptEndDate)
+                if (promptTitle != null && promptStartDate != null) {
+                    ImplementationHelper.findMatchingEventIds(cr, null, promptStartDate)
                 } else {
                     emptySet()
                 }
@@ -492,28 +490,33 @@ class CapacitorCalendarPlugin : Plugin() {
 
     /**
      * Attempts to find the ID of a newly created event by diffing current events against
-     * the pre-intent snapshot. Falls back to time-range-only matching if title matching
+     * the pre-intent snapshot. Falls back to start-time-only matching if title matching
      * yields no new results (handles the case where the user changed the title in the UI).
      * Returns null if no new event is found or if READ_CALENDAR permission is not granted.
+     *
+     * Note: This works reliably for calendar providers that write directly to the local
+     * CalendarContract (e.g., Samsung Calendar, AOSP Calendar). Calendar providers that
+     * write to a cloud API first (e.g., Google Calendar app) may not have the event in the
+     * local database when this function runs. Callers should handle a null return gracefully.
      */
     private fun findNewlyCreatedEventId(): Long? {
         return try {
             val cr = context.contentResolver
 
-            // First try: match on title + time (most specific)
-            if (promptTitle != null || promptStartDate != null || promptEndDate != null) {
+            // First try: match on title + start time (most specific)
+            if (promptTitle != null || promptStartDate != null) {
                 val currentIds =
-                    ImplementationHelper.findMatchingEventIds(cr, promptTitle, promptStartDate, promptEndDate)
+                    ImplementationHelper.findMatchingEventIds(cr, promptTitle, promptStartDate)
                 val newIds = currentIds - prePromptEventIds
                 if (newIds.isNotEmpty()) {
                     return newIds.max()
                 }
             }
 
-            // Fallback: match on time range only (handles user changing title in native UI)
-            if (promptStartDate != null || promptEndDate != null) {
+            // Fallback: match on start time only (handles user changing title in native UI)
+            if (promptStartDate != null) {
                 val currentIds =
-                    ImplementationHelper.findMatchingEventIds(cr, null, promptStartDate, promptEndDate)
+                    ImplementationHelper.findMatchingEventIds(cr, null, promptStartDate)
                 val newIds = currentIds - prePromptEventIds
                 if (newIds.isNotEmpty()) {
                     return newIds.max()

--- a/android/src/main/java/dev/barooni/capacitor/calendar/CapacitorCalendarPlugin.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/CapacitorCalendarPlugin.kt
@@ -30,6 +30,7 @@ import dev.barooni.capacitor.calendar.models.results.CreateEventWithPromptResult
 import dev.barooni.capacitor.calendar.models.results.ModifyEventWithPromptResult
 import dev.barooni.capacitor.calendar.models.results.RequestAllPermissionsResult
 import dev.barooni.capacitor.calendar.models.results.RequestPermissionResult
+import dev.barooni.capacitor.calendar.utils.ImplementationHelper
 
 @CapacitorPlugin(
     name = "CapacitorCalendar",
@@ -57,7 +58,10 @@ import dev.barooni.capacitor.calendar.models.results.RequestPermissionResult
 )
 class CapacitorCalendarPlugin : Plugin() {
     private val implementation: CapacitorCalendar by lazy { CapacitorCalendar(this) }
-    private var eventIdOptional = false
+    private var prePromptEventIds: Set<Long> = emptySet()
+    private var promptTitle: String? = null
+    private var promptStartDate: Long? = null
+    private var promptEndDate: Long? = null
 
     @PluginMethod
     fun checkPermission(call: PluginCall) {
@@ -209,6 +213,10 @@ class CapacitorCalendarPlugin : Plugin() {
     fun createEventWithPrompt(call: PluginCall) {
         try {
             val input = CreateEventWithPromptInput(call, "createEventWithPromptCallback")
+            promptTitle = input.title.ifEmpty { null }
+            promptStartDate = input.startDate
+            promptEndDate = input.endDate
+            prePromptEventIds = snapshotMatchingEventIds()
             implementation.createEventWithPrompt(input, ::startActivityForResult)
         } catch (error: Exception) {
             call.reject(error.message)
@@ -223,7 +231,8 @@ class CapacitorCalendarPlugin : Plugin() {
         if (call == null) {
             return
         }
-        call.resolve(CreateEventWithPromptResult().toJSON())
+        val newEventId = findNewlyCreatedEventId()
+        call.resolve(CreateEventWithPromptResult(newEventId).toJSON())
     }
 
     @PluginMethod
@@ -454,5 +463,66 @@ class CapacitorCalendarPlugin : Plugin() {
     @PluginMethod
     fun updateRemindersList(call: PluginCall) {
         call.unimplemented(PluginError.Unimplemented(::updateRemindersList.name).message)
+    }
+
+    /**
+     * Takes a snapshot of existing event IDs matching the current prompt criteria.
+     * Called before launching the native calendar intent so we can diff after it returns.
+     */
+    private fun snapshotMatchingEventIds(): Set<Long> {
+        return try {
+            val cr = context.contentResolver
+            val titleIds =
+                if (promptTitle != null || promptStartDate != null || promptEndDate != null) {
+                    ImplementationHelper.findMatchingEventIds(cr, promptTitle, promptStartDate, promptEndDate)
+                } else {
+                    emptySet()
+                }
+            val timeOnlyIds =
+                if (promptTitle != null && (promptStartDate != null || promptEndDate != null)) {
+                    ImplementationHelper.findMatchingEventIds(cr, null, promptStartDate, promptEndDate)
+                } else {
+                    emptySet()
+                }
+            titleIds + timeOnlyIds
+        } catch (_: SecurityException) {
+            emptySet()
+        }
+    }
+
+    /**
+     * Attempts to find the ID of a newly created event by diffing current events against
+     * the pre-intent snapshot. Falls back to time-range-only matching if title matching
+     * yields no new results (handles the case where the user changed the title in the UI).
+     * Returns null if no new event is found or if READ_CALENDAR permission is not granted.
+     */
+    private fun findNewlyCreatedEventId(): Long? {
+        return try {
+            val cr = context.contentResolver
+
+            // First try: match on title + time (most specific)
+            if (promptTitle != null || promptStartDate != null || promptEndDate != null) {
+                val currentIds =
+                    ImplementationHelper.findMatchingEventIds(cr, promptTitle, promptStartDate, promptEndDate)
+                val newIds = currentIds - prePromptEventIds
+                if (newIds.isNotEmpty()) {
+                    return newIds.max()
+                }
+            }
+
+            // Fallback: match on time range only (handles user changing title in native UI)
+            if (promptStartDate != null || promptEndDate != null) {
+                val currentIds =
+                    ImplementationHelper.findMatchingEventIds(cr, null, promptStartDate, promptEndDate)
+                val newIds = currentIds - prePromptEventIds
+                if (newIds.isNotEmpty()) {
+                    return newIds.max()
+                }
+            }
+
+            null
+        } catch (_: SecurityException) {
+            null
+        }
     }
 }

--- a/android/src/main/java/dev/barooni/capacitor/calendar/models/inputs/CreateEventWithPromptInput.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/models/inputs/CreateEventWithPromptInput.kt
@@ -10,7 +10,7 @@ data class CreateEventWithPromptInput(
     val call: PluginCall,
     val callbackName: String,
 ) {
-    private val title: String = call.getString("title", "") ?: ""
+    val title: String = call.getString("title", "") ?: ""
     val recurrence: EventRecurrenceRule? = call.getObject("recurrence")?.let { EventRecurrenceRule.parseRecurrence(it) }
     val location: String? = call.getString("location")
     val startDate: Long? = call.getLong("startDate")?.let { ImplementationHelper.getCalendarFromTimestamp(it).timeInMillis }

--- a/android/src/main/java/dev/barooni/capacitor/calendar/models/results/CreateEventWithPromptResult.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/models/results/CreateEventWithPromptResult.kt
@@ -3,10 +3,12 @@ package dev.barooni.capacitor.calendar.models.results
 import com.getcapacitor.JSObject
 import dev.barooni.capacitor.calendar.models.templates.JSResult
 
-class CreateEventWithPromptResult : JSResult {
+class CreateEventWithPromptResult(
+    private val id: Long? = null,
+) : JSResult {
     override fun toJSON(): JSObject {
         val result = JSObject()
-        result.put("id", null)
+        result.put("id", id?.toString())
         return result
     }
 }

--- a/android/src/main/java/dev/barooni/capacitor/calendar/utils/ImplementationHelper.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/utils/ImplementationHelper.kt
@@ -427,5 +427,63 @@ class ImplementationHelper {
                 CalendarContract.Events.STATUS_CANCELED -> "canceled"
                 else -> "none"
             }
+
+        /**
+         * Queries CalendarContract.Events for event IDs matching the given criteria.
+         * Used by createEventWithPrompt to snapshot existing events before the intent
+         * launches and to find newly created events after the intent returns.
+         *
+         * @param cr ContentResolver to query with
+         * @param title Optional event title to match (exact match)
+         * @param startDate Optional start date in millis to match (exact match on DTSTART)
+         * @param endDate Optional end date in millis to match (exact match on DTEND)
+         * @return Set of matching event IDs
+         */
+        fun findMatchingEventIds(
+            cr: ContentResolver,
+            title: String? = null,
+            startDate: Long? = null,
+            endDate: Long? = null,
+        ): Set<Long> {
+            val ids = mutableSetOf<Long>()
+            val projection = arrayOf(CalendarContract.Events._ID)
+
+            val selectionParts = mutableListOf<String>()
+            val selectionArgs = mutableListOf<String>()
+
+            if (!title.isNullOrEmpty()) {
+                selectionParts.add("${CalendarContract.Events.TITLE} = ?")
+                selectionArgs.add(title)
+            }
+            if (startDate != null) {
+                selectionParts.add("${CalendarContract.Events.DTSTART} = ?")
+                selectionArgs.add(startDate.toString())
+            }
+            if (endDate != null) {
+                selectionParts.add("${CalendarContract.Events.DTEND} = ?")
+                selectionArgs.add(endDate.toString())
+            }
+
+            if (selectionParts.isEmpty()) {
+                return ids
+            }
+
+            val selection = selectionParts.joinToString(" AND ")
+
+            cr.query(
+                CalendarContract.Events.CONTENT_URI,
+                projection,
+                selection,
+                selectionArgs.toTypedArray(),
+                null,
+            )?.use { cursor ->
+                while (cursor.moveToNext()) {
+                    val id = cursor.getLong(cursor.getColumnIndexOrThrow(CalendarContract.Events._ID))
+                    ids.add(id)
+                }
+            }
+
+            return ids
+        }
     }
 }

--- a/android/src/main/java/dev/barooni/capacitor/calendar/utils/ImplementationHelper.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/utils/ImplementationHelper.kt
@@ -429,21 +429,31 @@ class ImplementationHelper {
             }
 
         /**
+         * Tolerance window for timestamp matching (2 minutes).
+         * Native calendar apps may round or adjust timestamps when
+         * processing ACTION_INSERT intents, so exact-match queries
+         * can miss the newly created event.
+         */
+        private const val TIMESTAMP_TOLERANCE_MS = 120_000L
+
+        /**
          * Queries CalendarContract.Events for event IDs matching the given criteria.
          * Used by createEventWithPrompt to snapshot existing events before the intent
          * launches and to find newly created events after the intent returns.
          *
+         * Only matches on title and DTSTART. DTEND is intentionally excluded because
+         * some calendar providers (notably Google Calendar) store events with DURATION
+         * instead of DTEND, leaving the DTEND column NULL.
+         *
          * @param cr ContentResolver to query with
          * @param title Optional event title to match (exact match)
-         * @param startDate Optional start date in millis to match (exact match on DTSTART)
-         * @param endDate Optional end date in millis to match (exact match on DTEND)
+         * @param startDate Optional start date in millis to match (within tolerance window)
          * @return Set of matching event IDs
          */
         fun findMatchingEventIds(
             cr: ContentResolver,
             title: String? = null,
             startDate: Long? = null,
-            endDate: Long? = null,
         ): Set<Long> {
             val ids = mutableSetOf<Long>()
             val projection = arrayOf(CalendarContract.Events._ID)
@@ -456,12 +466,9 @@ class ImplementationHelper {
                 selectionArgs.add(title)
             }
             if (startDate != null) {
-                selectionParts.add("${CalendarContract.Events.DTSTART} = ?")
-                selectionArgs.add(startDate.toString())
-            }
-            if (endDate != null) {
-                selectionParts.add("${CalendarContract.Events.DTEND} = ?")
-                selectionArgs.add(endDate.toString())
+                selectionParts.add("${CalendarContract.Events.DTSTART} >= ? AND ${CalendarContract.Events.DTSTART} <= ?")
+                selectionArgs.add((startDate - TIMESTAMP_TOLERANCE_MS).toString())
+                selectionArgs.add((startDate + TIMESTAMP_TOLERANCE_MS).toString())
             }
 
             if (selectionParts.isEmpty()) {

--- a/src/sub-definitions/event-operations.ts
+++ b/src/sub-definitions/event-operations.ts
@@ -12,15 +12,20 @@ import type { EventEditAction } from '../schemas/types/event-edit-action';
 export interface EventOperations {
   /**
    * Opens the system calendar interface to create a new event.
-   * On Android always returns `null`.
-   * Fetch the events to find the ID of the newly created event.
+   * Returns the ID of the newly created event on both platforms.
+   *
+   * On iOS, the ID is retrieved directly from the event edit controller.
+   * On Android, the ID is retrieved by querying the calendar provider after
+   * the native UI returns. This requires `READ_CALENDAR` permission to be
+   * granted; if not available, `null` is returned. The ID may also be `null`
+   * if the user cancels or if the newly created event cannot be matched.
    *
    * @example
    * const options = {
    *   title: 'Test event',
    *   startDate: Date.now(),
    * }
-   * await CapacitorCalendar.createEventWithPrompt(options)
+   * const { id } = await CapacitorCalendar.createEventWithPrompt(options)
    *
    * @platform Android, iOS
    * @since 0.1.0


### PR DESCRIPTION
## Summary

On Android, `createEventWithPrompt` previously always returned `null` for the event ID because `Intent.ACTION_INSERT` does not provide result data in the `ActivityResult`. This change implements a snapshot-and-diff approach to retrieve the newly created event ID, bringing Android behavior in line with iOS.

## Approach

1. **Before** launching the native calendar intent, snapshot existing event IDs matching the input criteria (title, start date, end date) via `CalendarContract.Events`.
2. **After** the intent returns, re-query and diff against the snapshot to find newly created events.
3. **Fallback**: If title matching yields no results (e.g., user changed the title in the native UI), fall back to time-range-only matching.
4. Return the highest new event ID when multiple matches exist (most recently inserted).

## Graceful Degradation

- Returns `null` if `READ_CALENDAR` permission is not granted (catches `SecurityException`)
- Returns `null` if the user cancels the native calendar UI
- Returns `null` if no matching event can be found
- Fully backward compatible — the return type is already `Promise<{ id: string | null }>`

## Files Changed

| File | Change |
|------|--------|
| `CreateEventWithPromptResult.kt` | Accept optional `id: Long?` parameter |
| `CreateEventWithPromptInput.kt` | Make `title` field public (was private) |
| `ImplementationHelper.kt` | Add `findMatchingEventIds()` helper |
| `CapacitorCalendarPlugin.kt` | Remove unused `eventIdOptional`; add snapshot/diff logic |
| `event-operations.ts` | Update JSDoc to document new behavior |
| `README.md` | Auto-regenerated by docgen |

## Platform Parity

| Aspect | iOS | Android (after this PR) |
|--------|-----|------------------------|
| Returns event ID | Yes (from `EKEventEditViewController`) | Yes (from `CalendarContract` query) |
| Mechanism | Direct — same `EKEvent` instance | Heuristic — snapshot + diff |
| Cancel detection | `action == .canceled` | No new event in diff |
| Permission needed | Calendar access | `READ_CALENDAR` (graceful fallback to `null`) |