### PR TITLE
fix(android): avoid duplicate kotlin extension under AGP 9

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,12 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'org.jetbrains.kotlin.android'
+// AGP 9+ registers a `kotlin` extension via its built-in Kotlin support, so
+// applying the Kotlin Gradle plugin again would fail with "extension already
+// registered". Only apply it when that extension isn't present yet (AGP < 9).
+if (project.extensions.findByName('kotlin') == null) {
+    apply plugin: 'org.jetbrains.kotlin.android'
+}
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 android {


### PR DESCRIPTION
AGP 9's built-in Kotlin support registers a `kotlin` extension on every Android library module. This plugin's build.gradle also applies `org.jetbrains.kotlin.android` unconditionally, so under AGP 9 the build fails with:

  Cannot add extension with name 'kotlin', as there is an extension
  already registered with that name.

That failure aborts evaluation of android/build.gradle before the `android {}` block runs, which also surfaces as a separate "does not specify compileSdk" error further down the build.

Only apply the Kotlin Gradle plugin when the `kotlin` extension isn't already registered, so the module still works on AGP < 9 (which needs the explicit plugin) and AGP >= 9 (which provides it natively).