### PR TITLE
docs: clarify listEventsInRange overlap behavior and day queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,17 @@
 
 This file provides instructions for AI coding agents working on the `ebarooni/capacitor-calendar` codebase.
 
+## Writing Style
+
+Use plain, direct language.
+
+- Follow ASD-STE100 Simplified Technical English for vocabulary and sentence structure.
+- Apply Zinsser's four principles of quality writing:
+  1. Simplicity: Use common words. Prefer short sentences.
+  2. Brevity: Remove words that do not add meaning.
+  3. Clarity: State one idea per sentence. Avoid ambiguity.
+  4. Humanity: Write for a person, not a manual. Be direct and respectful.
+
 ## Root Folders
 
 - `android/`: Android implementation of the plugin

--- a/README.md
+++ b/README.md
@@ -175,7 +175,9 @@ await CapacitorCalendar.createEventWithPrompt({
 > [!NOTE]  
 > On Android, this method always returns null. If you need the event ID, call `listEventsInRange(...)` afterward.
 
-### List upcoming events
+### List events in a range
+
+`listEventsInRange` returns events that overlap the given range, not only events that start or end inside it. Multi-day events that span the interval are included.
 
 ```typescript
 const now = Date.now();
@@ -187,6 +189,20 @@ const { result: events } = await CapacitorCalendar.listEventsInRange({
 });
 
 console.log('Upcoming events:', events);
+```
+
+To list events on a single day, use that day's bounds:
+
+```typescript
+const startOfDay = new Date();
+startOfDay.setHours(0, 0, 0, 0);
+const startOfNextDay = new Date(startOfDay);
+startOfNextDay.setDate(startOfNextDay.getDate() + 1);
+
+const { result: todaysEvents } = await CapacitorCalendar.listEventsInRange({
+  from: startOfDay.getTime(),
+  to: startOfNextDay.getTime(),
+});
 ```
 
 ### Working with Calendars
@@ -561,7 +577,10 @@ Opens a dialog to delete an event.
 listEventsInRange(options: ListEventsInRangeOptions) => Promise<{ result: CalendarEvent[]; }>
 ```
 
-Retrieves the events within a date range.
+Retrieves events that overlap a date range.
+
+An event is included when its time interval intersects `[from, to]`, including
+multi-day events that span the range without starting or ending inside it.
 
 | Param         | Type                                                                          |
 | ------------- | ----------------------------------------------------------------------------- |
@@ -1153,10 +1172,10 @@ Update a reminders list with options.
 
 #### ListEventsInRangeOptions
 
-| Prop       | Type                | Description                    | Since |
-| ---------- | ------------------- | ------------------------------ | ----- |
-| **`from`** | <code>number</code> | The timestamp in milliseconds. | 7.1.0 |
-| **`to`**   | <code>number</code> | The timestamp in milliseconds. | 7.1.0 |
+| Prop       | Type                | Description                                                                                                                                                                             | Since |
+| ---------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| **`from`** | <code>number</code> | The start of the range, in milliseconds since the epoch. Events still in progress at this time are included.                                                                            | 7.1.0 |
+| **`to`**   | <code>number</code> | The end of the range, in milliseconds since the epoch. Events that begin at or after this time are typically excluded; prefer the next day's start when querying a single calendar day. | 7.1.0 |
 
 #### Calendar
 

--- a/example-app/src/js/example.js
+++ b/example-app/src/js/example.js
@@ -121,11 +121,9 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   document.querySelector('#list-events-in-range').addEventListener('click', async () => {
-    const now = new Date();
     const from = new Date();
-    from.setMonth(now.getMonth() - 1);
     const to = new Date();
-    to.setMonth(now.getMonth() + 1);
+    to.setMonth(from.getMonth() + 1);
 
     const result = await CapacitorCalendar.listEventsInRange({
       from: from.getTime(),

--- a/src/schemas/interfaces/list-events-in-range-options.ts
+++ b/src/schemas/interfaces/list-events-in-range-options.ts
@@ -3,14 +3,19 @@
  */
 export interface ListEventsInRangeOptions {
   /**
-   * The timestamp in milliseconds.
+   * The start of the range, in milliseconds since the epoch.
+   * Events still in progress at this time are included.
    *
+   * @example 1719792000000
    * @since 7.1.0
    */
   from: number;
   /**
-   * The timestamp in milliseconds.
+   * The end of the range, in milliseconds since the epoch.
+   * Events that begin at or after this time are typically excluded; prefer the
+   * next day's start when querying a single calendar day.
    *
+   * @example 1719878400000
    * @since 7.1.0
    */
   to: number;

--- a/src/sub-definitions/event-operations.ts
+++ b/src/sub-definitions/event-operations.ts
@@ -78,7 +78,21 @@ export interface EventOperations {
    */
   deleteEventWithPrompt(options: DeleteEventWithPromptOptions): Promise<{ deleted: boolean }>;
   /**
-   * Retrieves the events within a date range.
+   * Retrieves events that overlap a date range.
+   *
+   * An event is included when its time interval intersects `[from, to]`, including
+   * multi-day events that span the range without starting or ending inside it.
+   *
+   * @example
+   * const startOfDay = new Date();
+   * startOfDay.setHours(0, 0, 0, 0);
+   * const startOfNextDay = new Date(startOfDay);
+   * startOfNextDay.setDate(startOfNextDay.getDate() + 1);
+   *
+   * const { result } = await CapacitorCalendar.listEventsInRange({
+   *   from: startOfDay.getTime(),
+   *   to: startOfNextDay.getTime(),
+   * });
    *
    * @platform Android, iOS
    * @since 0.10.0


### PR DESCRIPTION
## Summary

- Document that `listEventsInRange` returns events whose time interval overlaps the given range, including multi-day events that span the range without starting or ending inside it.
- Add README usage example for querying a single calendar day via day-start to next-day-start bounds.
- Expand JSDoc on `listEventsInRange` and `ListEventsInRangeOptions` (`from`/`to` field semantics and examples).
- Add writing style guidelines to `AGENTS.md` for agent-authored docs and comments.

Closes: #143

## Test plan

- [x] Review README usage examples and generated API reference for accuracy
- [x] Confirm JSDoc renders correctly after `npm run docgen`
- [x] Verify overlap semantics match current Android and iOS implementations
