### PR TITLE
fix: correct and document calendar permission request methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,11 +49,18 @@ Changelogs for the versions supporting Capacitor 8.
 ### Added
 
 - `CheckPermissionOptions` for `checkPermission(...)`
+- `RequestPermissionOptions` for `requestPermission(...)`
 
 ### Fixed
 
 - Android `checkAllPermissions()` response shape now nests permission states under `result` (matching iOS and the TypeScript contract)
 - Android `checkPermission(...)` returns `"prompt"` for `readReminders` / `writeReminders` (aligned with `checkAllPermissions()`)
+- Android `requestAllPermissions()` now reports `readCalendar` from the read permission state (aligned with `checkAllPermissions()`)
+- Android `requestPermission(...)` distinguishes a missing scope (`Scope must be provided.`) from an invalid scope (`Invalid scope.`)
+
+### Changed
+
+- Documented platform limits for calendar permission request methods
 
 ## 8.3.0
 

--- a/README.md
+++ b/README.md
@@ -303,14 +303,7 @@ checkPermission(options: CheckPermissionOptions) => Promise<{ result: Permission
 ```
 
 Retrieves the current permission state for a given scope.
-
-On Android, `readReminders` and `writeReminders` are not supported by the OS.
-Calling this method with those scopes resolves with `result: "prompt"` (they are
-never granted on Android).
-
-On iOS 17+, EventKit may report write-only authorization. For `writeCalendar` /
-`writeReminders`, write-only maps to `"granted"`. For `readCalendar` /
-`readReminders`, write-only maps to `"prompt"`.
+On Android, `readReminders` and `writeReminders` resolve to `"prompt"`.
 
 | Param         | Type                                                                      |
 | ------------- | ------------------------------------------------------------------------- |
@@ -331,16 +324,7 @@ checkAllPermissions() => Promise<{ result: CheckAllPermissionsResult; }>
 ```
 
 Retrieves the current state of all permissions.
-
-The resolved value is always nested under `result` with string keys matching
-`CalendarPermissionScope` values (`readCalendar`, `writeCalendar`, `readReminders`,
-`writeReminders`) and lowercase <a href="#permissionstate">`PermissionState`</a> string values.
-
-On Android, `readReminders` and `writeReminders` always resolve to `"prompt"`
-(reminders are not supported on Android).
-
-On iOS 17+, write-only authorization is mapped per scope the same way as
-{@link checkPermission}.
+On Android, reminder keys always resolve to `"prompt"`.
 
 **Returns:** <code>Promise&lt;{ result: <a href="#checkallpermissionsresult">CheckAllPermissionsResult</a>; }&gt;</code>
 
@@ -353,14 +337,15 @@ On iOS 17+, write-only authorization is mapped per scope the same way as
 ### requestPermission(...)
 
 ```typescript
-requestPermission(options: { scope: CalendarPermissionScope; }) => Promise<{ result: PermissionState; }>
+requestPermission(options: RequestPermissionOptions) => Promise<{ result: PermissionState; }>
 ```
 
 Requests permission for a given scope.
+On Android, `readReminders` and `writeReminders` reject with `Invalid scope.`
 
-| Param         | Type                                                                                    |
-| ------------- | --------------------------------------------------------------------------------------- |
-| **`options`** | <code>{ scope: <a href="#calendarpermissionscope">CalendarPermissionScope</a>; }</code> |
+| Param         | Type                                                                          |
+| ------------- | ----------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#requestpermissionoptions">RequestPermissionOptions</a></code> |
 
 **Returns:** <code>Promise&lt;{ result: <a href="#permissionstate">PermissionState</a>; }&gt;</code>
 
@@ -377,6 +362,7 @@ requestAllPermissions() => Promise<{ result: RequestAllPermissionsResult; }>
 ```
 
 Requests permission for all calendar and reminder permissions.
+On Android, only calendar permissions are requested; reminder keys stay `"prompt"`.
 
 **Returns:** <code>Promise&lt;{ result: <a href="#checkallpermissionsresult">CheckAllPermissionsResult</a>; }&gt;</code>
 
@@ -1034,6 +1020,14 @@ Options for {@link CalendarAccess#checkPermission}.
 | ----------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ------------ |
 | **`scope`** | <code><a href="#calendarpermissionscope">CalendarPermissionScope</a></code> | The permission scope to check. On Android, `readReminders` and `writeReminders` resolve to `"prompt"` (reminders are not supported on Android). | 8.3.1 | Android, iOS |
 
+#### RequestPermissionOptions
+
+Options for {@link CalendarAccess#requestPermission}.
+
+| Prop        | Type                                                                        | Description                      | Since | Platform     |
+| ----------- | --------------------------------------------------------------------------- | -------------------------------- | ----- | ------------ |
+| **`scope`** | <code><a href="#calendarpermissionscope">CalendarPermissionScope</a></code> | The permission scope to request. | 8.3.1 | Android, iOS |
+
 #### CreateEventWithPromptOptions
 
 | Prop               | Type                                                                | Description                                                                                                                                                                                      | Since | Platform     |
@@ -1451,12 +1445,12 @@ Construct a type with a set of properties K of type T
 
 #### CalendarPermissionScope
 
-| Members               | Value                         | Description                                                                                                                                                                   | Since | Platform     |
-| --------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ------------ |
-| **`READ_CALENDAR`**   | <code>'readCalendar'</code>   | Permission required for reading calendar events.                                                                                                                              | 7.1.0 | Android, iOS |
-| **`READ_REMINDERS`**  | <code>'readReminders'</code>  | Permission required for reading reminders. On Android, reminders are not supported. `checkPermission` and `checkAllPermissions` return `"prompt"` for this scope.             | 7.1.0 | iOS          |
-| **`WRITE_CALENDAR`**  | <code>'writeCalendar'</code>  | Permission required for adding or modifying calendar events.                                                                                                                  | 7.1.0 | Android, iOS |
-| **`WRITE_REMINDERS`** | <code>'writeReminders'</code> | Permission required for adding or modifying reminders. On Android, reminders are not supported. `checkPermission` and `checkAllPermissions` return `"prompt"` for this scope. | 7.1.0 | iOS          |
+| Members               | Value                         | Description                                                                                                                                                                                                                      | Since | Platform     |
+| --------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ------------ |
+| **`READ_CALENDAR`**   | <code>'readCalendar'</code>   | Permission required for reading calendar events.                                                                                                                                                                                 | 7.1.0 | Android, iOS |
+| **`READ_REMINDERS`**  | <code>'readReminders'</code>  | Permission required for reading reminders. On Android, reminders are not supported. `checkPermission` and `checkAllPermissions` return `"prompt"` for this scope. `requestPermission` rejects with `Invalid scope.`.             | 7.1.0 | iOS          |
+| **`WRITE_CALENDAR`**  | <code>'writeCalendar'</code>  | Permission required for adding or modifying calendar events.                                                                                                                                                                     | 7.1.0 | Android, iOS |
+| **`WRITE_REMINDERS`** | <code>'writeReminders'</code> | Permission required for adding or modifying reminders. On Android, reminders are not supported. `checkPermission` and `checkAllPermissions` return `"prompt"` for this scope. `requestPermission` rejects with `Invalid scope.`. | 7.1.0 | iOS          |
 
 #### EventAvailability
 

--- a/android/src/main/java/dev/barooni/capacitor/calendar/models/inputs/RequestPermissionInput.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/models/inputs/RequestPermissionInput.kt
@@ -13,13 +13,11 @@ sealed class RequestPermissionInput {
         override val call: PluginCall,
         override val callbackName: String,
     ) : RequestPermissionInput() {
-        override val scope: CalendarPermissionScope =
-            call
-                .getString("scope")
-                ?.let { CalendarPermissionScope.fromValue(it) }
-                ?: throw PluginError.MissingScope
+        override val scope: CalendarPermissionScope
 
         init {
+            val rawScope = call.getString("scope") ?: throw PluginError.MissingScope
+            scope = CalendarPermissionScope.fromValue(rawScope) ?: throw PluginError.InvalidScope
             if (scope == CalendarPermissionScope.WRITE_REMINDERS || scope == CalendarPermissionScope.READ_REMINDERS) {
                 throw PluginError.InvalidScope
             }

--- a/android/src/main/java/dev/barooni/capacitor/calendar/models/results/RequestAllPermissionsResult.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/models/results/RequestAllPermissionsResult.kt
@@ -16,7 +16,7 @@ data class RequestAllPermissionsResult(
             getPermissionState(CalendarPermissionScope.WRITE_CALENDAR.value) ?: throw PluginError.UnhandledPermissionState
         permissions.put(CalendarPermissionScope.WRITE_CALENDAR.value, writeCalendarState.toString())
         val readCalendarState =
-            getPermissionState(CalendarPermissionScope.WRITE_CALENDAR.value) ?: throw PluginError.UnhandledPermissionState
+            getPermissionState(CalendarPermissionScope.READ_CALENDAR.value) ?: throw PluginError.UnhandledPermissionState
         permissions.put(CalendarPermissionScope.READ_CALENDAR.value, readCalendarState.toString())
         permissions.put(CalendarPermissionScope.WRITE_REMINDERS.value, PermissionState.PROMPT.toString())
         permissions.put(CalendarPermissionScope.READ_REMINDERS.value, PermissionState.PROMPT.toString())

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import type { RecurrenceRule } from './schemas/interfaces/recurrence-rule';
 import type { Reminder } from './schemas/interfaces/reminder';
 import type { ReminderRecurrenceRule } from './schemas/interfaces/reminder-recurrence-rule';
 import type { RemindersList } from './schemas/interfaces/reminders-list';
+import type { RequestPermissionOptions } from './schemas/interfaces/request-permission-options';
 import type { SelectCalendarsWithPromptOptions } from './schemas/interfaces/select-calendars-with-prompt-options';
 import type { UpdateRemindersListOptions } from './schemas/interfaces/update-reminders-list-options';
 import type { UpdateRemindersListResult } from './schemas/interfaces/update-reminders-list-result';
@@ -94,6 +95,7 @@ export type {
   ReminderRecurrenceRule,
   RemindersList,
   RequestAllPermissionsResult,
+  RequestPermissionOptions,
   SelectCalendarsWithPromptOptions,
   UpdateRemindersListOptions,
   UpdateRemindersListResult,

--- a/src/schemas/enums/calendar-permission-scope.ts
+++ b/src/schemas/enums/calendar-permission-scope.ts
@@ -23,6 +23,7 @@ export enum CalendarPermissionScope {
    *
    * On Android, reminders are not supported. `checkPermission` and
    * `checkAllPermissions` return `"prompt"` for this scope.
+   * `requestPermission` rejects with `Invalid scope.`.
    *
    * @permissions
    * | Platform  | Required |
@@ -52,6 +53,7 @@ export enum CalendarPermissionScope {
    *
    * On Android, reminders are not supported. `checkPermission` and
    * `checkAllPermissions` return `"prompt"` for this scope.
+   * `requestPermission` rejects with `Invalid scope.`.
    *
    * @permissions
    * | Platform  | Required |

--- a/src/schemas/interfaces/request-permission-options.ts
+++ b/src/schemas/interfaces/request-permission-options.ts
@@ -1,0 +1,17 @@
+import type { CalendarPermissionScope } from '../enums/calendar-permission-scope';
+
+/**
+ * Options for {@link CalendarAccess#requestPermission}.
+ *
+ * @since 8.3.1
+ */
+export interface RequestPermissionOptions {
+  /**
+   * The permission scope to request.
+   *
+   * @example CalendarPermissionScope.READ_CALENDAR
+   * @platform Android, iOS
+   * @since 8.3.1
+   */
+  scope: CalendarPermissionScope;
+}

--- a/src/sub-definitions/calendar-access.ts
+++ b/src/sub-definitions/calendar-access.ts
@@ -2,6 +2,7 @@ import type { PermissionState } from '@capacitor/core';
 
 import type { CalendarPermissionScope } from '../schemas/enums/calendar-permission-scope';
 import type { CheckPermissionOptions } from '../schemas/interfaces/check-permission-options';
+import type { RequestPermissionOptions } from '../schemas/interfaces/request-permission-options';
 
 /**
  * @since 7.1.0
@@ -9,21 +10,14 @@ import type { CheckPermissionOptions } from '../schemas/interfaces/check-permiss
 export interface CalendarAccess {
   /**
    * Retrieves the current permission state for a given scope.
-   *
-   * On Android, `readReminders` and `writeReminders` are not supported by the OS.
-   * Calling this method with those scopes resolves with `result: "prompt"` (they are
-   * never granted on Android).
-   *
-   * On iOS 17+, EventKit may report write-only authorization. For `writeCalendar` /
-   * `writeReminders`, write-only maps to `"granted"`. For `readCalendar` /
-   * `readReminders`, write-only maps to `"prompt"`.
+   * On Android, `readReminders` and `writeReminders` resolve to `"prompt"`.
    *
    * @example
    * CapacitorCalendar.checkPermission({ scope: CalendarPermissionScope.READ_CALENDAR });
    *
    * @throws {Error} `Scope must be provided.` — when `scope` is missing.
-   * @throws {Error} `Invalid scope.` — when `scope` is not a valid `CalendarPermissionScope` value.
-   * @throws {Error} `Unhandled permission state.` — when the native authorization status cannot be mapped.
+   * @throws {Error} `Invalid scope.` — when `scope` is invalid.
+   * @throws {Error} `Unhandled permission state.` — when the native status cannot be mapped.
    *
    * @platform Android, iOS
    * @since 0.1.0
@@ -32,18 +26,9 @@ export interface CalendarAccess {
 
   /**
    * Retrieves the current state of all permissions.
+   * On Android, reminder keys always resolve to `"prompt"`.
    *
-   * The resolved value is always nested under `result` with string keys matching
-   * `CalendarPermissionScope` values (`readCalendar`, `writeCalendar`, `readReminders`,
-   * `writeReminders`) and lowercase `PermissionState` string values.
-   *
-   * On Android, `readReminders` and `writeReminders` always resolve to `"prompt"`
-   * (reminders are not supported on Android).
-   *
-   * On iOS 17+, write-only authorization is mapped per scope the same way as
-   * {@link checkPermission}.
-   *
-   * @throws {Error} `Unhandled permission state.` — when a native authorization status cannot be mapped.
+   * @throws {Error} `Unhandled permission state.` — when a native status cannot be mapped.
    *
    * @platform Android, iOS
    * @since 0.1.0
@@ -52,20 +37,27 @@ export interface CalendarAccess {
 
   /**
    * Requests permission for a given scope.
+   * On Android, `readReminders` and `writeReminders` reject with `Invalid scope.`
    *
    * @example
-   * this.requestPermission({ scope: CalendarPermissionScope.READ_CALENDAR });
+   * CapacitorCalendar.requestPermission({ scope: CalendarPermissionScope.READ_CALENDAR });
    *
-   * @deprecated Use {@link requestWriteOnlyCalendarAccess}, {@link requestReadOnlyCalendarAccess},
-   * {@link requestFullCalendarAccess} or {@link requestFullRemindersAccess} instead.
+   * @throws {Error} `Scope must be provided.` — when `scope` is missing.
+   * @throws {Error} `Invalid scope.` — when `scope` is invalid, or a reminders scope on Android.
+   *
+   * @deprecated Use {@link requestWriteOnlyCalendarAccess},
+   * {@link requestReadOnlyCalendarAccess} (Android),
+   * {@link requestFullCalendarAccess} (also for read on iOS),
+   * or {@link requestFullRemindersAccess} instead.
    *
    * @platform Android, iOS
    * @since 0.1.0
    */
-  requestPermission(options: { scope: CalendarPermissionScope }): Promise<{ result: PermissionState }>;
+  requestPermission(options: RequestPermissionOptions): Promise<{ result: PermissionState }>;
 
   /**
    * Requests permission for all calendar and reminder permissions.
+   * On Android, only calendar permissions are requested; reminder keys stay `"prompt"`.
    *
    * @deprecated Use {@link requestFullCalendarAccess} or {@link requestFullRemindersAccess} instead.
    * @platform Android, iOS

--- a/src/web.ts
+++ b/src/web.ts
@@ -2,7 +2,6 @@ import type { PermissionState } from '@capacitor/core';
 import { WebPlugin } from '@capacitor/core';
 
 import type { CapacitorCalendarPlugin } from './definitions';
-import type { CalendarPermissionScope } from './schemas/enums/calendar-permission-scope';
 import type { Calendar } from './schemas/interfaces/calendar';
 import type { CalendarEvent } from './schemas/interfaces/calendar-event';
 import type { CalendarSource } from './schemas/interfaces/calendar-source';
@@ -31,6 +30,7 @@ import type { ModifyReminderOptions } from './schemas/interfaces/modify-reminder
 import type { OpenCalendarOptions } from './schemas/interfaces/open-calendar-options';
 import type { Reminder } from './schemas/interfaces/reminder';
 import type { RemindersList } from './schemas/interfaces/reminders-list';
+import type { RequestPermissionOptions } from './schemas/interfaces/request-permission-options';
 import type { SelectCalendarsWithPromptOptions } from './schemas/interfaces/select-calendars-with-prompt-options';
 import type { UpdateRemindersListOptions } from './schemas/interfaces/update-reminders-list-options';
 import type { UpdateRemindersListResult } from './schemas/interfaces/update-reminders-list-result';
@@ -48,7 +48,7 @@ export class CapacitorCalendarWeb extends WebPlugin implements CapacitorCalendar
     return this.throwUnimplemented(this.checkAllPermissions.name);
   }
 
-  public requestPermission(_options: { scope: CalendarPermissionScope }): Promise<{ result: PermissionState }> {
+  public requestPermission(_options: RequestPermissionOptions): Promise<{ result: PermissionState }> {
     return this.throwUnimplemented(this.requestPermission.name);
   }
 


### PR DESCRIPTION
## Summary
- Fix Android `requestAllPermissions` so `readCalendar` uses the read permission state, and `requestPermission` distinguishes missing vs invalid scope
- Add `RequestPermissionOptions` and wire it through the TypeScript / web API
- Document Android reminder and deprecation behavior for the calendar permission request methods

## Test plan
- [ ] On Android, call `requestAllPermissions()` and confirm `readCalendar` matches `checkAllPermissions()` when read/write differ
- [ ] On Android, call `requestPermission` without `scope` → `Scope must be provided.`; with invalid scope → `Invalid scope.`
- [ ] On Android, reminder scopes on `requestPermission` still reject with `Invalid scope.`
- [ ] Confirm generated docs show `RequestPermissionOptions` and the updated request-method notes

Closes: #239