### PR TITLE
docs(ios): clarify requestFullRemindersAccess result values

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,8 @@ requestFullRemindersAccess() => Promise<{ result: PermissionState; }>
 ```
 
 Requests read and write access to the reminders.
+Resolves with `"granted"` or `"denied"` (never `"prompt"`).
+A grant covers both `readReminders` and `writeReminders`.
 
 **Returns:** <code>Promise&lt;{ result: <a href="#permissionstate">PermissionState</a>; }&gt;</code>
 

--- a/src/sub-definitions/reminders-access.ts
+++ b/src/sub-definitions/reminders-access.ts
@@ -6,12 +6,16 @@ import type { PermissionState } from '@capacitor/core';
 export interface RemindersAccess {
   /**
    * Requests read and write access to the reminders.
+   * Resolves with `"granted"` or `"denied"` (never `"prompt"`).
+   * A grant covers both `readReminders` and `writeReminders`.
    *
    * @permissions
    * | Platform  | Required |
    * |-----------|---------------------|
    * | iOS 17+   | `NSRemindersFullAccessUsageDescription` |
    * | iOS 10-16 | `NSRemindersUsageDescription` |
+   *
+   * @throws {Error} when EventKit fails or required Info.plist keys are missing.
    *
    * @platform iOS
    * @see {@link CalendarPermissionScope}


### PR DESCRIPTION
## Summary
- Clarify JSDoc for `requestFullRemindersAccess`: success `result` is `"granted"` or `"denied"` (never `"prompt"`), and a grant covers both `readReminders` and `writeReminders`.
- Note that EventKit failures or missing Info.plist keys can reject.
- Mirror the success-result notes in the generated README API section.

Closes: #240

## Test plan
- [ ] Confirm README `requestFullRemindersAccess` section matches the updated JSDoc wording
- [ ] Confirm Info.plist keys for iOS 17+ and pre-17 are still listed in the JSDoc `@permissions` table
- [ ] Confirm no signature or runtime changes