### PR TITLE
fix(android): delete plugin-created calendars with sync-adapter URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Contents
 
 - [Version 8.x.x](#version-8xx)
-  - [8.3.1](#831)
+  - [8.4.0](#840)
   - [8.3.0](#830)
   - [8.2.0](#820)
   - [8.1.0](#810)
@@ -44,7 +44,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Changelogs for the versions supporting Capacitor 8.
 
-## 8.3.1
+## 8.4.0
 
 ### Added
 
@@ -57,6 +57,7 @@ Changelogs for the versions supporting Capacitor 8.
 - Android `checkPermission(...)` returns `"prompt"` for `readReminders` / `writeReminders` (aligned with `checkAllPermissions()`)
 - Android `requestAllPermissions()` now reports `readCalendar` from the read permission state (aligned with `checkAllPermissions()`)
 - Android `requestPermission(...)` distinguishes a missing scope (`Scope must be provided.`) from an invalid scope (`Invalid scope.`)
+- Android `deleteCalendar(...)` for calendars created via `createCalendar(...)` (sync-adapter URI)
 
 ### Changed
 

--- a/android/src/main/java/dev/barooni/capacitor/calendar/implementation/CapacitorCalendar.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/implementation/CapacitorCalendar.kt
@@ -188,10 +188,37 @@ class CapacitorCalendar(
     }
 
     fun deleteCalendar(input: DeleteCalendarInput) {
-        val uri: Uri = ContentUris.withAppendedId(CalendarContract.Calendars.CONTENT_URI, input.id)
         val cr = plugin.context.contentResolver
-        val rowsDeleted = cr.delete(uri, null, null)
+        val calendarUri = ContentUris.withAppendedId(CalendarContract.Calendars.CONTENT_URI, input.id)
+        val projection =
+            arrayOf(
+                CalendarContract.Calendars.ACCOUNT_NAME,
+                CalendarContract.Calendars.ACCOUNT_TYPE,
+            )
 
+        val (accountName, accountType) =
+            cr.query(calendarUri, projection, null, null, null)?.use { cursor ->
+                if (!cursor.moveToFirst()) {
+                    throw PluginError.FailedToDelete
+                }
+                val name =
+                    cursor.getString(cursor.getColumnIndexOrThrow(CalendarContract.Calendars.ACCOUNT_NAME))
+                        ?: throw PluginError.FailedToDelete
+                val type =
+                    cursor.getString(cursor.getColumnIndexOrThrow(CalendarContract.Calendars.ACCOUNT_TYPE))
+                        ?: throw PluginError.FailedToDelete
+                name to type
+            } ?: throw PluginError.FailedToDelete
+
+        val deleteUri =
+            calendarUri
+                .buildUpon()
+                .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")
+                .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_NAME, accountName)
+                .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_TYPE, accountType)
+                .build()
+
+        val rowsDeleted = cr.delete(deleteUri, null, null)
         if (rowsDeleted < 1) {
             throw PluginError.FailedToDelete
         }

--- a/example-app/package-lock.json
+++ b/example-app/package-lock.json
@@ -20,7 +20,7 @@
     },
     "..": {
       "name": "@ebarooni/capacitor-calendar",
-      "version": "8.3.1",
+      "version": "8.4.0",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^8.0.0",

--- a/example-app/src/index.html
+++ b/example-app/src/index.html
@@ -71,6 +71,16 @@
         </ion-item>
         <ion-item lines="none" class="ion-no-padding">
           <ion-input
+            id="calendar-id-input"
+            label="Calendar ID"
+            label-placement="stacked"
+            placeholder="73D6F2A1-4B8C-4E9A-9F3D-1C2B5A7E8D90"
+            helper-text="The identifier of the calendar to use"
+          >
+          </ion-input>
+        </ion-item>
+        <ion-item lines="none" class="ion-no-padding">
+          <ion-input
             id="reminders-list-id-input"
             label="Reminders list ID"
             label-placement="stacked"
@@ -82,9 +92,11 @@
 
         <ion-list id="methods-list" class="ion-margin-top">
           <ion-button id="check-all-permissions" expand="block" fill="outline">Check all permissions</ion-button>
+          <ion-button id="create-calendar" expand="block">Create calendar</ion-button>
           <ion-button id="create-event" expand="block">Create event</ion-button>
           <ion-button id="create-event-with-prompt" expand="block">Create event with prompt</ion-button>
           <ion-button id="create-reminders-list" expand="block">Create reminders list</ion-button>
+          <ion-button id="delete-calendar" expand="block">Delete calendar</ion-button>
           <ion-button id="delete-event" expand="block">Delete event</ion-button>
           <ion-button id="delete-event-with-prompt" expand="block">Delete event with prompt</ion-button>
           <ion-button id="delete-events-by-id" expand="block">Delete events by id</ion-button>
@@ -92,6 +104,7 @@
           <ion-button id="get-reminders-lists" expand="block">Get reminders lists</ion-button>
           <ion-button id="list-calendars" expand="block">List calendars</ion-button>
           <ion-button id="list-events-in-range" expand="block">List events in range</ion-button>
+          <ion-button id="modify-calendar" expand="block">Modify calendar</ion-button>
           <ion-button id="open-calendar" expand="block">Open calendar</ion-button>
           <ion-button id="open-reminders" expand="block">Open reminders</ion-button>
           <ion-button id="request-full-calendar-access" expand="block" fill="outline"

--- a/example-app/src/js/example.js
+++ b/example-app/src/js/example.js
@@ -6,6 +6,18 @@ document.addEventListener('DOMContentLoaded', () => {
     console.log('#checkAllPermissions', result);
   });
 
+  document.querySelector('#create-calendar').addEventListener('click', async () => {
+    const result = await CapacitorCalendar.createCalendar({
+      accountName: 'plugin@example.com',
+      color: '#6750A4',
+      ownerAccount: 'plugin@example.com',
+      title: 'Plugin Test Calendar',
+    });
+
+    getCalendarIdInput().value = result.id;
+    console.log('#createCalendar', result);
+  });
+
   document.querySelector('#create-event').addEventListener('click', async () => {
     const { result: calendars } = await CapacitorCalendar.listCalendars();
     const startDate = Date.now();
@@ -78,6 +90,11 @@ document.addEventListener('DOMContentLoaded', () => {
     console.log('#createRemindersList', result);
   });
 
+  document.querySelector('#delete-calendar').addEventListener('click', async () => {
+    await CapacitorCalendar.deleteCalendar({ id: getCalendarIdInput().value });
+    console.log('#deleteCalendar');
+  });
+
   document.querySelector('#delete-event').addEventListener('click', async () => {
     await CapacitorCalendar.deleteEvent({
       id: getEventIdInput().value,
@@ -138,6 +155,15 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  document.querySelector('#modify-calendar').addEventListener('click', async () => {
+    await CapacitorCalendar.modifyCalendar({
+      color: '#B3261E',
+      id: getCalendarIdInput().value,
+      title: 'Updated Plugin Test Calendar',
+    });
+    console.log('#modifyCalendar');
+  });
+
   document.querySelector('#open-calendar').addEventListener('click', async () => {
     await CapacitorCalendar.openCalendar({ date: Date.now() });
     console.log('#openCalendar');
@@ -169,6 +195,10 @@ document.addEventListener('DOMContentLoaded', () => {
     console.log('#updateRemindersList', result);
   });
 });
+
+function getCalendarIdInput() {
+  return document.querySelector('#calendar-id-input');
+}
 
 function getEventIdInput() {
   return document.querySelector('#event-id-input');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebarooni/capacitor-calendar",
-  "version": "8.3.1",
+  "version": "8.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebarooni/capacitor-calendar",
-      "version": "8.3.1",
+      "version": "8.4.0",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebarooni/capacitor-calendar",
-  "version": "8.3.1",
+  "version": "8.4.0",
   "description": "A capacitor plugin for managing calendar events on iOS and Android, with reminders support on iOS.",
   "author": "Ehsan Barooni",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Fix Android `deleteCalendar` so calendars created via `createCalendar` can be deleted: look up account name/type and delete with the CalendarContract sync-adapter URI.
- Unknown or missing ids still reject with `FailedToDelete` / `MissingId`; `modifyCalendar` is unchanged.
- Raise planned release version to 8.4.0 and document the fix in the changelog.

Closes: #246

## Test plan
- [ ] On Android, create a local calendar with `createCalendar`, then delete it with `deleteCalendar` using the returned id — expect success
- [ ] Call `deleteCalendar` with a missing or unknown id — expect a clear rejection
- [ ] Confirm `modifyCalendar` still updates display name/color for an existing calendar