### PR TITLE
fix(ios): open Calendar without canOpenURL false negatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Changelogs for the versions supporting Capacitor 8.
 
 ### Fixed
 
+- iOS `openCalendar(...)` no longer rejects when `canOpenURL` fails without a `calshow` query scheme (opens Calendar directly and reports launch failure)
 - Android `checkAllPermissions()` response shape now nests permission states under `result` (matching iOS and the TypeScript contract)
 - Android `checkPermission(...)` returns `"prompt"` for `readReminders` / `writeReminders` (aligned with `checkAllPermissions()`)
 - Android `requestAllPermissions()` now reports `readCalendar` from the read permission state (aligned with `checkAllPermissions()`)
@@ -61,6 +62,7 @@ Changelogs for the versions supporting Capacitor 8.
 
 ### Changed
 
+- `OpenCalendarOptions.date` is optional and documented as milliseconds since the epoch (defaults to now)
 - Documented platform limits for calendar permission request methods
 
 ## 8.3.0

--- a/README.md
+++ b/README.md
@@ -1235,9 +1235,9 @@ Options for {@link CalendarAccess#requestPermission}.
 
 #### OpenCalendarOptions
 
-| Prop       | Type                | Default                 | Since |
-| ---------- | ------------------- | ----------------------- | ----- |
-| **`date`** | <code>number</code> | <code>Date.now()</code> | 7.1.0 |
+| Prop       | Type                | Description                                                        | Default                 | Since | Platform     |
+| ---------- | ------------------- | ------------------------------------------------------------------ | ----------------------- | ----- | ------------ |
+| **`date`** | <code>number</code> | The date to open the calendar at, in milliseconds since the epoch. | <code>Date.now()</code> | 7.1.0 | Android, iOS |
 
 #### CreateCalendarOptions
 

--- a/ios/Plugin/Implementation/CapacitorCalendar.swift
+++ b/ios/Plugin/Implementation/CapacitorCalendar.swift
@@ -323,9 +323,6 @@ class CapacitorCalendar: NSObject {
         guard let url = URL(string: "calshow:\(input.getDate())") else {
             throw PluginError.invalidUrl
         }
-        guard await UIApplication.shared.canOpenURL(url) else {
-            throw PluginError.unableToOpenUrl
-        }
         let success = await UIApplication.shared.open(url, options: [:])
         if !success {
             throw PluginError.failedToLaunchCalendar

--- a/src/schemas/interfaces/open-calendar-options.ts
+++ b/src/schemas/interfaces/open-calendar-options.ts
@@ -3,8 +3,12 @@
  */
 export interface OpenCalendarOptions {
   /**
+   * The date to open the calendar at, in milliseconds since the epoch.
+   *
+   * @example Date.now()
    * @default Date.now()
+   * @platform Android, iOS
    * @since 7.1.0
    */
-  date: number;
+  date?: number;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -138,7 +138,7 @@ export class CapacitorCalendarWeb extends WebPlugin implements CapacitorCalendar
     return this.throwUnimplemented(this.getRemindersLists.name);
   }
 
-  public openCalendar(_options: OpenCalendarOptions): Promise<void> {
+  public openCalendar(_options?: OpenCalendarOptions): Promise<void> {
     return this.throwUnimplemented(this.openCalendar.name);
   }
 


### PR DESCRIPTION
## Summary
- iOS `openCalendar` no longer pre-checks `canOpenURL` for `calshow:`, which falsely rejected when the host app lacked `LSApplicationQueriesSchemes`
- `OpenCalendarOptions.date` is optional and documented as milliseconds since the epoch (defaults to now on Android and iOS)
- Web stub accepts optional options; README and CHANGELOG updated

Closes: #250

## Test plan
- [ ] On iOS without `calshow` in `LSApplicationQueriesSchemes`, call `openCalendar()` and confirm Calendar opens
- [ ] Call `openCalendar({ date: Date.now() })` and confirm it opens at the expected date
- [ ] Confirm TypeScript accepts `openCalendar()` and `openCalendar({})`
- [ ] On Android, confirm missing `date` still opens at now