### PR TITLE
fix(ios): distinguish cancel from done in selectCalendarsWithPrompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,12 +50,15 @@ Changelogs for the versions supporting Capacitor 8.
 
 - `CheckPermissionOptions` for `checkPermission(...)`
 - `RequestPermissionOptions` for `requestPermission(...)`
+- `SelectCalendarsWithPromptResult` for `selectCalendarsWithPrompt(...)`
 
 ### Fixed
 
 - iOS `openCalendar(...)` no longer rejects when `canOpenURL` fails without a `calshow` query scheme (opens Calendar directly and reports launch failure)
 - Android `checkAllPermissions()` response shape now nests permission states under `result` (matching iOS and the TypeScript contract)
 - Android `checkPermission(...)` returns `"prompt"` for `readReminders` / `writeReminders` (aligned with `checkAllPermissions()`)
+- iOS `selectCalendarsWithPrompt(...)` cancel now returns an empty `result` (Done still returns the selected calendars)
+- iOS `selectCalendarsWithPrompt(...)` no longer leaves a Promise hanging when called again while the chooser is open (new call is rejected)
 - Android `requestAllPermissions()` now reports `readCalendar` from the read permission state (aligned with `checkAllPermissions()`)
 - Android `requestPermission(...)` distinguishes a missing scope (`Scope must be provided.`) from an invalid scope (`Invalid scope.`)
 - Android `deleteCalendar(...)` for calendars created via `createCalendar(...)` (sync-adapter URI)

--- a/README.md
+++ b/README.md
@@ -617,16 +617,22 @@ Saves pending calendar changes.
 ### selectCalendarsWithPrompt(...)
 
 ```typescript
-selectCalendarsWithPrompt(options?: SelectCalendarsWithPromptOptions | undefined) => Promise<{ result: Calendar[]; }>
+selectCalendarsWithPrompt(options?: SelectCalendarsWithPromptOptions | undefined) => Promise<SelectCalendarsWithPromptResult>
 ```
 
 Opens a system interface to choose one or multiple calendars.
+
+On confirm, `result` contains the calendars the user selected.
+On cancel, `result` is an empty array.
+
+If a chooser is already presented, a new call is rejected; the in-flight
+call continues until the user confirms or cancels.
 
 | Param         | Type                                                                                          |
 | ------------- | --------------------------------------------------------------------------------------------- |
 | **`options`** | <code><a href="#selectcalendarswithpromptoptions">SelectCalendarsWithPromptOptions</a></code> |
 
-**Returns:** <code>Promise&lt;{ result: Calendar[]; }&gt;</code>
+**Returns:** <code>Promise&lt;<a href="#selectcalendarswithpromptresult">SelectCalendarsWithPromptResult</a>&gt;</code>
 
 **Since:** 0.2.0
 
@@ -1198,6 +1204,12 @@ Options for {@link CalendarAccess#requestPermission}.
 | ---------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
 | **`from`** | <code>number</code> | The start of the range, in milliseconds since the epoch. Events still in progress at this time are included.                                                                            | 7.1.0 |
 | **`to`**   | <code>number</code> | The end of the range, in milliseconds since the epoch. Events that begin at or after this time are typically excluded; prefer the next day's start when querying a single calendar day. | 7.1.0 |
+
+#### SelectCalendarsWithPromptResult
+
+| Prop         | Type                    | Description                                                               | Since | Platform |
+| ------------ | ----------------------- | ------------------------------------------------------------------------- | ----- | -------- |
+| **`result`** | <code>Calendar[]</code> | Calendars the user confirmed in the chooser. Empty when the user cancels. | 8.4.0 | iOS      |
 
 #### Calendar
 

--- a/example-app/src/index.html
+++ b/example-app/src/index.html
@@ -89,6 +89,19 @@
           >
           </ion-input>
         </ion-item>
+        <ion-item lines="none" class="ion-no-padding">
+          <ion-select
+            id="select-calendars-multiple-select"
+            label="Select calendars multiple"
+            label-placement="stacked"
+            interface="popover"
+            value="false"
+            helper-text="Allow selecting more than one calendar in the chooser"
+          >
+            <ion-select-option value="false">Single</ion-select-option>
+            <ion-select-option value="true">Multiple</ion-select-option>
+          </ion-select>
+        </ion-item>
 
         <ion-list id="methods-list" class="ion-margin-top">
           <ion-button id="check-all-permissions" expand="block" fill="outline">Check all permissions</ion-button>
@@ -113,6 +126,7 @@
           <ion-button id="request-full-reminders-access" expand="block" fill="outline"
             >Request full reminders access</ion-button
           >
+          <ion-button id="select-calendars-with-prompt" expand="block">Select calendars with prompt</ion-button>
           <ion-button id="update-reminders-list" expand="block">Update reminders list</ion-button>
         </ion-list>
       </ion-content>

--- a/example-app/src/js/example.js
+++ b/example-app/src/js/example.js
@@ -184,6 +184,13 @@ document.addEventListener('DOMContentLoaded', () => {
     console.log('#requestFullRemindersAccess', result);
   });
 
+  document.querySelector('#select-calendars-with-prompt').addEventListener('click', async () => {
+    const result = await CapacitorCalendar.selectCalendarsWithPrompt({
+      multiple: getSelectCalendarsMultiple(),
+    });
+    console.log('#selectCalendarsWithPrompt', result);
+  });
+
   document.querySelector('#update-reminders-list').addEventListener('click', async () => {
     const result = await CapacitorCalendar.updateRemindersList({
       color: 'indigo',
@@ -224,6 +231,10 @@ function getEventSpan() {
 
 function getRemindersListIdInput() {
   return document.querySelector('#reminders-list-id-input');
+}
+
+function getSelectCalendarsMultiple() {
+  return document.querySelector('#select-calendars-multiple-select').value === 'true';
 }
 
 function pickNonHolidayCalendar(calendars) {

--- a/ios/Plugin/CapacitorCalendarPlugin.swift
+++ b/ios/Plugin/CapacitorCalendarPlugin.swift
@@ -170,14 +170,13 @@ public class CapacitorCalendarPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     @objc public func selectCalendarsWithPrompt(_ call: CAPPluginCall) {
-        Task {
-            do {
-                let input = SelectCalendarsWithPromptInput(call: call)
-                let result = try await implementation.selectCalendarsWithPrompt(input: input)
-                resolveCall(call, result)
-            } catch let error {
-                rejectCall(call, error)
+        let input = SelectCalendarsWithPromptInput(call: call)
+        implementation.selectCalendarsWithPrompt(input: input) { result, error in
+            if let error {
+                self.rejectCall(call, error)
+                return
             }
+            self.resolveCall(call, result)
         }
     }
 

--- a/ios/Plugin/Implementation/CapacitorCalendar.swift
+++ b/ios/Plugin/Implementation/CapacitorCalendar.swift
@@ -8,7 +8,7 @@ class CapacitorCalendar: NSObject {
     private let eventStore = EKEventStore()
     private var modifyEventWithPromptContinuation: CheckedContinuation<ModifyEventWithPromptResult, Error>?
     private let plugin: CapacitorCalendarPlugin
-    private var selectCalendarsWithPromptContinuation: CheckedContinuation<SelectCalendarsWithPromptResult, Error>?
+    private var selectCalendarsWithPromptCompletion: ((SelectCalendarsWithPromptResult?, Error?) -> Void)?
 
     init(plugin: CapacitorCalendarPlugin) {
         self.plugin = plugin
@@ -276,25 +276,32 @@ class CapacitorCalendar: NSObject {
         try eventStore.save(event, span: input.getSpan())
     }
 
-    func selectCalendarsWithPrompt(input: SelectCalendarsWithPromptInput) async throws -> SelectCalendarsWithPromptResult {
+    func selectCalendarsWithPrompt(
+        input: SelectCalendarsWithPromptInput,
+        completion: @escaping (SelectCalendarsWithPromptResult?, Error?) -> Void
+    ) {
         guard let viewController = plugin.bridge?.viewController else {
-            throw PluginError.viewControllerMissing
+            completion(nil, PluginError.viewControllerMissing)
+            return
         }
-        return try await withCheckedThrowingContinuation { continuation in
-            Task { @MainActor in
-                let calendarChooser = EKCalendarChooser(
-                    selectionStyle: input.getSelectionStyle(),
-                    displayStyle: input.getDisplayStyle(),
-                    eventStore: eventStore
-                )
-                calendarChooser.showsDoneButton = true
-                calendarChooser.showsCancelButton = true
-                calendarChooser.delegate = self
+        guard selectCalendarsWithPromptCompletion == nil else {
+            completion(nil, PluginError.customError("Calendar chooser is already presented."))
+            return
+        }
 
-                viewController.present(UINavigationController(rootViewController: calendarChooser), animated: true) {
-                    self.selectCalendarsWithPromptContinuation = continuation
-                }
-            }
+        selectCalendarsWithPromptCompletion = completion
+
+        Task { @MainActor in
+            let calendarChooser = EKCalendarChooser(
+                selectionStyle: input.getSelectionStyle(),
+                displayStyle: input.getDisplayStyle(),
+                eventStore: eventStore
+            )
+            calendarChooser.showsDoneButton = true
+            calendarChooser.showsCancelButton = true
+            calendarChooser.delegate = self
+
+            viewController.present(UINavigationController(rootViewController: calendarChooser), animated: true)
         }
     }
 
@@ -597,17 +604,17 @@ class CapacitorCalendar: NSObject {
 
 extension CapacitorCalendar: EKCalendarChooserDelegate {
     func calendarChooserDidFinish(_ calendarChooser: EKCalendarChooser) {
-        selectCalendarsWithPromptContinuation?.resume(returning: SelectCalendarsWithPromptResult(calendarChooser.selectedCalendars))
-        self.plugin.bridge?.viewController?.dismiss(animated: true) {
-            self.selectCalendarsWithPromptContinuation = nil
-        }
+        let completion = selectCalendarsWithPromptCompletion
+        selectCalendarsWithPromptCompletion = nil
+        completion?(SelectCalendarsWithPromptResult(calendarChooser.selectedCalendars), nil)
+        plugin.bridge?.viewController?.dismiss(animated: true)
     }
 
     func calendarChooserDidCancel(_ calendarChooser: EKCalendarChooser) {
-        selectCalendarsWithPromptContinuation?.resume(returning: SelectCalendarsWithPromptResult(calendarChooser.selectedCalendars))
-        self.plugin.bridge?.viewController?.dismiss(animated: true) {
-            self.selectCalendarsWithPromptContinuation = nil
-        }
+        let completion = selectCalendarsWithPromptCompletion
+        selectCalendarsWithPromptCompletion = nil
+        completion?(SelectCalendarsWithPromptResult([]), nil)
+        plugin.bridge?.viewController?.dismiss(animated: true)
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import type { ReminderRecurrenceRule } from './schemas/interfaces/reminder-recur
 import type { RemindersList } from './schemas/interfaces/reminders-list';
 import type { RequestPermissionOptions } from './schemas/interfaces/request-permission-options';
 import type { SelectCalendarsWithPromptOptions } from './schemas/interfaces/select-calendars-with-prompt-options';
+import type { SelectCalendarsWithPromptResult } from './schemas/interfaces/select-calendars-with-prompt-result';
 import type { UpdateRemindersListOptions } from './schemas/interfaces/update-reminders-list-options';
 import type { UpdateRemindersListResult } from './schemas/interfaces/update-reminders-list-result';
 import type { EventEditAction } from './schemas/types/event-edit-action';
@@ -97,6 +98,7 @@ export type {
   RequestAllPermissionsResult,
   RequestPermissionOptions,
   SelectCalendarsWithPromptOptions,
+  SelectCalendarsWithPromptResult,
   UpdateRemindersListOptions,
   UpdateRemindersListResult,
 };

--- a/src/schemas/interfaces/select-calendars-with-prompt-result.ts
+++ b/src/schemas/interfaces/select-calendars-with-prompt-result.ts
@@ -1,0 +1,15 @@
+import type { Calendar } from './calendar';
+
+/**
+ * @since 8.4.0
+ */
+export interface SelectCalendarsWithPromptResult {
+  /**
+   * Calendars the user confirmed in the chooser.
+   * Empty when the user cancels.
+   *
+   * @platform iOS
+   * @since 8.4.0
+   */
+  result: Calendar[];
+}

--- a/src/sub-definitions/calendar-operations.ts
+++ b/src/sub-definitions/calendar-operations.ts
@@ -5,6 +5,7 @@ import type { DeleteCalendarOptions } from '../schemas/interfaces/delete-calenda
 import type { ModifyCalendarOptions } from '../schemas/interfaces/modify-calendar-options';
 import type { OpenCalendarOptions } from '../schemas/interfaces/open-calendar-options';
 import type { SelectCalendarsWithPromptOptions } from '../schemas/interfaces/select-calendars-with-prompt-options';
+import type { SelectCalendarsWithPromptResult } from '../schemas/interfaces/select-calendars-with-prompt-result';
 
 export interface CalendarOperations {
   /**
@@ -17,10 +18,16 @@ export interface CalendarOperations {
   /**
    * Opens a system interface to choose one or multiple calendars.
    *
+   * On confirm, `result` contains the calendars the user selected.
+   * On cancel, `result` is an empty array.
+   *
+   * If a chooser is already presented, a new call is rejected; the in-flight
+   * call continues until the user confirms or cancels.
+   *
    * @platform iOS
    * @since 0.2.0
    */
-  selectCalendarsWithPrompt(options?: SelectCalendarsWithPromptOptions): Promise<{ result: Calendar[] }>;
+  selectCalendarsWithPrompt(options?: SelectCalendarsWithPromptOptions): Promise<SelectCalendarsWithPromptResult>;
   /**
    * Retrieves a list of calendar sources.
    *

--- a/src/web.ts
+++ b/src/web.ts
@@ -32,6 +32,7 @@ import type { Reminder } from './schemas/interfaces/reminder';
 import type { RemindersList } from './schemas/interfaces/reminders-list';
 import type { RequestPermissionOptions } from './schemas/interfaces/request-permission-options';
 import type { SelectCalendarsWithPromptOptions } from './schemas/interfaces/select-calendars-with-prompt-options';
+import type { SelectCalendarsWithPromptResult } from './schemas/interfaces/select-calendars-with-prompt-result';
 import type { UpdateRemindersListOptions } from './schemas/interfaces/update-reminders-list-options';
 import type { UpdateRemindersListResult } from './schemas/interfaces/update-reminders-list-result';
 import type { EventEditAction } from './schemas/types/event-edit-action';
@@ -106,7 +107,9 @@ export class CapacitorCalendarWeb extends WebPlugin implements CapacitorCalendar
     return this.throwUnimplemented(this.modifyEvent.name);
   }
 
-  public selectCalendarsWithPrompt(_options?: SelectCalendarsWithPromptOptions): Promise<{ result: Calendar[] }> {
+  public selectCalendarsWithPrompt(
+    _options?: SelectCalendarsWithPromptOptions,
+  ): Promise<SelectCalendarsWithPromptResult> {
     return this.throwUnimplemented(this.selectCalendarsWithPrompt.name);
   }
 


### PR DESCRIPTION
## Summary
- iOS cancel now resolves with an empty `result`; Done still returns the selected calendars
- Reject a second call while the chooser is open so the in-flight Promise cannot hang
- Add and export `SelectCalendarsWithPromptResult`, document cancel/confirm/re-entry, and wire the method into the example app

## Test plan
- [ ] On iOS, open the chooser and tap Cancel → `{ result: [] }`
- [ ] On iOS, select calendar(s) and tap Done → `{ result: [...] }` with the selection
- [ ] While the chooser is open, call `selectCalendarsWithPrompt` again → new call rejects; first call still settles on Done/Cancel
- [ ] Example app: use Single/Multiple select, then Select calendars with prompt; confirm console output

Closes: #249