### PR TITLE
feat: add useFallbackCalendar to getDefaultCalendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Changelogs for the versions supporting Capacitor 8.
 - `CheckPermissionOptions` for `checkPermission(...)`
 - `RequestPermissionOptions` for `requestPermission(...)`
 - `SelectCalendarsWithPromptResult` for `selectCalendarsWithPrompt(...)`
+- `GetDefaultCalendarOptions.useFallbackCalendar` for `getDefaultCalendar(...)` (when true, falls back to the first available calendar if there is no system default on Android and iOS)
 
 ### Fixed
 
@@ -62,7 +63,6 @@ Changelogs for the versions supporting Capacitor 8.
 - Android `requestAllPermissions()` now reports `readCalendar` from the read permission state (aligned with `checkAllPermissions()`)
 - Android `requestPermission(...)` distinguishes a missing scope (`Scope must be provided.`) from an invalid scope (`Invalid scope.`)
 - Android `deleteCalendar(...)` for calendars created via `createCalendar(...)` (sync-adapter URI)
-- Android `getDefaultCalendar()` now uses the same default-calendar selection as `createEvent` when `calendarId` is omitted (primary calendar, else first available)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Changelogs for the versions supporting Capacitor 8.
 - Android `requestAllPermissions()` now reports `readCalendar` from the read permission state (aligned with `checkAllPermissions()`)
 - Android `requestPermission(...)` distinguishes a missing scope (`Scope must be provided.`) from an invalid scope (`Invalid scope.`)
 - Android `deleteCalendar(...)` for calendars created via `createCalendar(...)` (sync-adapter URI)
+- Android `getDefaultCalendar()` now uses the same default-calendar selection as `createEvent` when `calendarId` is omitted (primary calendar, else first available)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the latest updates and release history.
 - [`selectCalendarsWithPrompt(...)`](#selectcalendarswithprompt)
 - [`fetchAllCalendarSources()`](#fetchallcalendarsources)
 - [`listCalendars()`](#listcalendars)
-- [`getDefaultCalendar()`](#getdefaultcalendar)
+- [`getDefaultCalendar(...)`](#getdefaultcalendar)
 - [`openCalendar(...)`](#opencalendar)
 - [`createCalendar(...)`](#createcalendar)
 - [`deleteCalendar(...)`](#deletecalendar)
@@ -672,16 +672,22 @@ Retrieves a list of all available calendars.
 
 ---
 
-### getDefaultCalendar()
+### getDefaultCalendar(...)
 
 ```typescript
-getDefaultCalendar() => Promise<{ result: Calendar | null; }>
+getDefaultCalendar(options?: GetDefaultCalendarOptions | undefined) => Promise<{ result: Calendar | null; }>
 ```
 
 Retrieves the default calendar.
 
-On Android, the default calendar is the primary calendar when one is set;
-otherwise the first available calendar.
+The system default is the primary calendar on Android and
+`defaultCalendarForNewEvents` on iOS. When neither exists and
+`useFallbackCalendar` is true, the first available calendar is returned.
+Otherwise the method returns `null` when there is no system default.
+
+| Param         | Type                                                                            |
+| ------------- | ------------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#getdefaultcalendaroptions">GetDefaultCalendarOptions</a></code> |
 
 **Returns:** <code>Promise&lt;{ result: <a href="#calendar">Calendar</a> | null; }&gt;</code>
 
@@ -1247,6 +1253,12 @@ Options for {@link CalendarAccess#requestPermission}.
 | ------------------ | ----------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------ | ----- |
 | **`displayStyle`** | <code><a href="#calendarchooserdisplaystyle">CalendarChooserDisplayStyle</a></code> |                            | <code>CalendarChooserDisplayStyle.ALL_CALENDARS</code> | 7.1.0 |
 | **`multiple`**     | <code>boolean</code>                                                                | Allow multiple selections. | <code>false</code>                                     | 7.1.0 |
+
+#### GetDefaultCalendarOptions
+
+| Prop                      | Type                 | Description                                                                 | Default            | Since | Platform     |
+| ------------------------- | -------------------- | --------------------------------------------------------------------------- | ------------------ | ----- | ------------ |
+| **`useFallbackCalendar`** | <code>boolean</code> | When there is no system default calendar, use the first available calendar. | <code>false</code> | 8.4.0 | Android, iOS |
 
 #### OpenCalendarOptions
 

--- a/README.md
+++ b/README.md
@@ -680,6 +680,9 @@ getDefaultCalendar() => Promise<{ result: Calendar | null; }>
 
 Retrieves the default calendar.
 
+On Android, the default calendar is the primary calendar when one is set;
+otherwise the first available calendar.
+
 **Returns:** <code>Promise&lt;{ result: <a href="#calendar">Calendar</a> | null; }&gt;</code>
 
 **Since:** 0.3.0

--- a/android/src/main/java/dev/barooni/capacitor/calendar/CapacitorCalendarPlugin.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/CapacitorCalendarPlugin.kt
@@ -30,6 +30,7 @@ import dev.barooni.capacitor.calendar.models.results.CreateEventWithPromptResult
 import dev.barooni.capacitor.calendar.models.results.ModifyEventWithPromptResult
 import dev.barooni.capacitor.calendar.models.results.RequestAllPermissionsResult
 import dev.barooni.capacitor.calendar.models.results.RequestPermissionResult
+import dev.barooni.capacitor.calendar.models.templates.JSResult
 
 @CapacitorPlugin(
     name = "CapacitorCalendar",
@@ -306,11 +307,12 @@ class CapacitorCalendarPlugin : Plugin() {
 
     @PluginMethod(returnType = PluginMethod.RETURN_PROMISE)
     fun getDefaultCalendar(call: PluginCall) {
-        try {
-            val result = implementation.getDefaultCalendar()
-            call.resolve(result.toJSON())
-        } catch (error: Exception) {
-            call.reject(error.message)
+        implementation.getDefaultCalendar { result, error ->
+            if (error != null) {
+                rejectCall(call, error)
+                return@getDefaultCalendar
+            }
+            resolveCall(call, result)
         }
     }
 
@@ -454,5 +456,27 @@ class CapacitorCalendarPlugin : Plugin() {
     @PluginMethod
     fun updateRemindersList(call: PluginCall) {
         call.unimplemented(PluginError.Unimplemented(::updateRemindersList.name).message)
+    }
+
+    private fun rejectCall(
+        call: PluginCall,
+        error: Exception?,
+    ) {
+        call.reject(error?.message ?: PluginError.CustomError("An unknown error has occurred.").message)
+    }
+
+    private fun resolveCall(call: PluginCall) {
+        resolveCall(call, null)
+    }
+
+    private fun resolveCall(
+        call: PluginCall,
+        result: JSResult?,
+    ) {
+        if (result != null) {
+            call.resolve(result.toJSON())
+        } else {
+            call.resolve()
+        }
     }
 }

--- a/android/src/main/java/dev/barooni/capacitor/calendar/CapacitorCalendarPlugin.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/CapacitorCalendarPlugin.kt
@@ -19,6 +19,7 @@ import dev.barooni.capacitor.calendar.models.inputs.DeleteCalendarInput
 import dev.barooni.capacitor.calendar.models.inputs.DeleteEventInput
 import dev.barooni.capacitor.calendar.models.inputs.DeleteEventWithPromptInput
 import dev.barooni.capacitor.calendar.models.inputs.DeleteEventsByIdInput
+import dev.barooni.capacitor.calendar.models.inputs.GetDefaultCalendarInput
 import dev.barooni.capacitor.calendar.models.inputs.ListEventsInRangeInput
 import dev.barooni.capacitor.calendar.models.inputs.ModifyCalendarInput
 import dev.barooni.capacitor.calendar.models.inputs.ModifyEvent
@@ -307,12 +308,17 @@ class CapacitorCalendarPlugin : Plugin() {
 
     @PluginMethod(returnType = PluginMethod.RETURN_PROMISE)
     fun getDefaultCalendar(call: PluginCall) {
-        implementation.getDefaultCalendar { result, error ->
-            if (error != null) {
-                rejectCall(call, error)
-                return@getDefaultCalendar
+        try {
+            val input = GetDefaultCalendarInput(call)
+            implementation.getDefaultCalendar(input) { result, error ->
+                if (error != null) {
+                    rejectCall(call, error)
+                    return@getDefaultCalendar
+                }
+                resolveCall(call, result)
             }
-            resolveCall(call, result)
+        } catch (error: Exception) {
+            rejectCall(call, error)
         }
     }
 

--- a/android/src/main/java/dev/barooni/capacitor/calendar/implementation/CapacitorCalendar.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/implementation/CapacitorCalendar.kt
@@ -36,6 +36,7 @@ import dev.barooni.capacitor.calendar.models.results.DeleteEventsByIdResult
 import dev.barooni.capacitor.calendar.models.results.GetDefaultCalendarResult
 import dev.barooni.capacitor.calendar.models.results.ListCalendarsResult
 import dev.barooni.capacitor.calendar.models.results.ListEventsInRangeResult
+import dev.barooni.capacitor.calendar.models.templates.PluginCompletion
 import dev.barooni.capacitor.calendar.utils.ImplementationHelper
 
 class CapacitorCalendar(
@@ -144,11 +145,15 @@ class CapacitorCalendar(
         return ListCalendarsResult(calendars)
     }
 
-    fun getDefaultCalendar(): GetDefaultCalendarResult {
-        val cr = plugin.context.contentResolver
-        val calendars = ImplementationHelper.listCalendars(cr)
-        val primaryCalendar = calendars.find { it.isPrimary == true }
-        return GetDefaultCalendarResult(primaryCalendar)
+    fun getDefaultCalendar(completion: PluginCompletion<GetDefaultCalendarResult>) {
+        try {
+            val cr = plugin.context.contentResolver
+            val calendars = ImplementationHelper.listCalendars(cr)
+            val defaultCalendar = ImplementationHelper.resolveDefaultCalendar(calendars)
+            completion(GetDefaultCalendarResult(defaultCalendar), null)
+        } catch (error: Exception) {
+            completion(null, error)
+        }
     }
 
     fun openCalendar(input: OpenCalendarInput) {

--- a/android/src/main/java/dev/barooni/capacitor/calendar/implementation/CapacitorCalendar.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/implementation/CapacitorCalendar.kt
@@ -20,6 +20,7 @@ import dev.barooni.capacitor.calendar.models.inputs.DeleteCalendarInput
 import dev.barooni.capacitor.calendar.models.inputs.DeleteEventInput
 import dev.barooni.capacitor.calendar.models.inputs.DeleteEventWithPromptInput
 import dev.barooni.capacitor.calendar.models.inputs.DeleteEventsByIdInput
+import dev.barooni.capacitor.calendar.models.inputs.GetDefaultCalendarInput
 import dev.barooni.capacitor.calendar.models.inputs.ListEventsInRangeInput
 import dev.barooni.capacitor.calendar.models.inputs.ModifyCalendarInput
 import dev.barooni.capacitor.calendar.models.inputs.ModifyEvent
@@ -145,11 +146,15 @@ class CapacitorCalendar(
         return ListCalendarsResult(calendars)
     }
 
-    fun getDefaultCalendar(completion: PluginCompletion<GetDefaultCalendarResult>) {
+    fun getDefaultCalendar(
+        input: GetDefaultCalendarInput,
+        completion: PluginCompletion<GetDefaultCalendarResult>,
+    ) {
         try {
             val cr = plugin.context.contentResolver
             val calendars = ImplementationHelper.listCalendars(cr)
-            val defaultCalendar = ImplementationHelper.resolveDefaultCalendar(calendars)
+            val defaultCalendar =
+                ImplementationHelper.resolveDefaultCalendar(calendars, input.useFallbackCalendar)
             completion(GetDefaultCalendarResult(defaultCalendar), null)
         } catch (error: Exception) {
             completion(null, error)

--- a/android/src/main/java/dev/barooni/capacitor/calendar/models/inputs/GetDefaultCalendarInput.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/models/inputs/GetDefaultCalendarInput.kt
@@ -1,0 +1,9 @@
+package dev.barooni.capacitor.calendar.models.inputs
+
+import com.getcapacitor.PluginCall
+
+data class GetDefaultCalendarInput(
+    private val call: PluginCall,
+) {
+    val useFallbackCalendar: Boolean = call.getBoolean("useFallbackCalendar", false)
+}

--- a/android/src/main/java/dev/barooni/capacitor/calendar/models/templates/PluginCompletion.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/models/templates/PluginCompletion.kt
@@ -1,0 +1,8 @@
+package dev.barooni.capacitor.calendar.models.templates
+
+/**
+ * Completion handler matching the `(Result?, Error?) -> Void` pattern.
+ *
+ * Call with a result and `null` error on success, or `null` result and an error on failure.
+ */
+typealias PluginCompletion<T> = (T?, Exception?) -> Unit

--- a/android/src/main/java/dev/barooni/capacitor/calendar/utils/ImplementationHelper.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/utils/ImplementationHelper.kt
@@ -132,35 +132,19 @@ class ImplementationHelper {
             )
         }
 
-        fun getDefaultCalendarId(cr: ContentResolver): Long {
-            val uri = CalendarContract.Calendars.CONTENT_URI
-            val projection =
-                arrayOf(
-                    CalendarContract.Calendars._ID,
-                    CalendarContract.Calendars.IS_PRIMARY,
-                )
-
-            var fallbackCalendarId: Long? = null
-            cr.query(uri, projection, null, null, null)?.use { cursor ->
-                if (cursor.count == 0) {
-                    throw PluginError.NoCalendarsAvailable
-                }
-
-                while (cursor.moveToNext()) {
-                    val id = cursor.getLong(cursor.getColumnIndexOrThrow(CalendarContract.Calendars._ID))
-                    val isPrimary = cursor.getInt(cursor.getColumnIndexOrThrow(CalendarContract.Calendars.IS_PRIMARY)) == 1
-
-                    if (isPrimary) {
-                        return id
-                    }
-
-                    if (fallbackCalendarId == null) {
-                        fallbackCalendarId = id
-                    }
-                }
+        fun resolveDefaultCalendar(calendars: List<CalendarInfo>): CalendarInfo? {
+            if (calendars.isEmpty()) {
+                return null
             }
 
-            return fallbackCalendarId ?: throw PluginError.NoCalendarsAvailable
+            return calendars.find { it.isPrimary == true } ?: calendars.first()
+        }
+
+        fun getDefaultCalendarId(cr: ContentResolver): Long {
+            val calendar =
+                resolveDefaultCalendar(listCalendars(cr))
+                    ?: throw PluginError.NoCalendarsAvailable
+            return calendar.id.toLong()
         }
 
         fun listCalendars(cr: ContentResolver): List<CalendarInfo> {

--- a/android/src/main/java/dev/barooni/capacitor/calendar/utils/ImplementationHelper.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/utils/ImplementationHelper.kt
@@ -132,17 +132,25 @@ class ImplementationHelper {
             )
         }
 
-        fun resolveDefaultCalendar(calendars: List<CalendarInfo>): CalendarInfo? {
+        fun resolveDefaultCalendar(
+            calendars: List<CalendarInfo>,
+            useFallbackCalendar: Boolean,
+        ): CalendarInfo? {
             if (calendars.isEmpty()) {
                 return null
             }
 
-            return calendars.find { it.isPrimary == true } ?: calendars.first()
+            val primary = calendars.find { it.isPrimary == true }
+            if (primary != null) {
+                return primary
+            }
+
+            return if (useFallbackCalendar) calendars.first() else null
         }
 
         fun getDefaultCalendarId(cr: ContentResolver): Long {
             val calendar =
-                resolveDefaultCalendar(listCalendars(cr))
+                resolveDefaultCalendar(listCalendars(cr), useFallbackCalendar = true)
                     ?: throw PluginError.NoCalendarsAvailable
             return calendar.id.toLong()
         }

--- a/example-app/src/index.html
+++ b/example-app/src/index.html
@@ -114,6 +114,7 @@
           <ion-button id="delete-event-with-prompt" expand="block">Delete event with prompt</ion-button>
           <ion-button id="delete-events-by-id" expand="block">Delete events by id</ion-button>
           <ion-button id="delete-reminders-list" expand="block">Delete reminders list</ion-button>
+          <ion-button id="get-default-calendar" expand="block">Get default calendar</ion-button>
           <ion-button id="get-reminders-lists" expand="block">Get reminders lists</ion-button>
           <ion-button id="list-calendars" expand="block">List calendars</ion-button>
           <ion-button id="list-events-in-range" expand="block">List events in range</ion-button>

--- a/example-app/src/js/example.js
+++ b/example-app/src/js/example.js
@@ -128,10 +128,15 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   document.querySelector('#get-default-calendar').addEventListener('click', async () => {
-    const result = await CapacitorCalendar.getDefaultCalendar();
-    console.log('#getDefaultCalendar', result);
-    if (result.result?.id) {
-      getCalendarIdInput().value = result.result.id;
+    const withoutFallback = await CapacitorCalendar.getDefaultCalendar();
+    console.log('#getDefaultCalendar (useFallbackCalendar: false)', withoutFallback);
+
+    const withFallback = await CapacitorCalendar.getDefaultCalendar({ useFallbackCalendar: true });
+    console.log('#getDefaultCalendar (useFallbackCalendar: true)', withFallback);
+
+    const result = withFallback.result ?? withoutFallback.result;
+    if (result?.id) {
+      getCalendarIdInput().value = result.id;
     }
   });
 

--- a/example-app/src/js/example.js
+++ b/example-app/src/js/example.js
@@ -127,6 +127,14 @@ document.addEventListener('DOMContentLoaded', () => {
     await CapacitorCalendar.deleteRemindersList({ id });
   });
 
+  document.querySelector('#get-default-calendar').addEventListener('click', async () => {
+    const result = await CapacitorCalendar.getDefaultCalendar();
+    console.log('#getDefaultCalendar', result);
+    if (result.result?.id) {
+      getCalendarIdInput().value = result.result.id;
+    }
+  });
+
   document.querySelector('#get-reminders-lists').addEventListener('click', async () => {
     const result = await CapacitorCalendar.getRemindersLists();
     console.log('#getRemindersLists', result);

--- a/ios/Plugin.xcodeproj/project.pbxproj
+++ b/ios/Plugin.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		7CABD3832FDF14E200A864E4 /* UpdateRemindersListResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CABD3822FDF14D700A864E4 /* UpdateRemindersListResult.swift */; };
 		7CC0E7E52EED9551004B5497 /* RecurrenceInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC0E7E42EED9551004B5497 /* RecurrenceInput.swift */; };
 		7CE36AF02FDEB2940081E142 /* DeleteRemindersListInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CE36AEF2FDEB28C0081E142 /* DeleteRemindersListInput.swift */; };
+		7C0DEF022FDF210100A864E4 /* GetDefaultCalendarInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0DEF012FDF210100A864E4 /* GetDefaultCalendarInput.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -148,6 +149,7 @@
 		7CABD3822FDF14D700A864E4 /* UpdateRemindersListResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateRemindersListResult.swift; sourceTree = "<group>"; };
 		7CC0E7E42EED9551004B5497 /* RecurrenceInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecurrenceInput.swift; sourceTree = "<group>"; };
 		7CE36AEF2FDEB28C0081E142 /* DeleteRemindersListInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteRemindersListInput.swift; sourceTree = "<group>"; };
+		7C0DEF012FDF210100A864E4 /* GetDefaultCalendarInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDefaultCalendarInput.swift; sourceTree = "<group>"; };
 		91781294A431A2A7CC6EB714 /* Pods-Plugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Plugin.release.xcconfig"; path = "Pods/Target Support Files/Pods-Plugin/Pods-Plugin.release.xcconfig"; sourceTree = "<group>"; };
 		96ED1B6440D6672E406C8D19 /* Pods-PluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PluginTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PluginTests/Pods-PluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		F65BB2953ECE002E1EF3E424 /* Pods-PluginTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PluginTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PluginTests/Pods-PluginTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -232,6 +234,7 @@
 		7C265CAA2EA98E62005E867C /* Inputs */ = {
 			isa = PBXGroup;
 			children = (
+				7C0DEF012FDF210100A864E4 /* GetDefaultCalendarInput.swift */,
 				7CABD3802FDF140A00A864E4 /* UpdateRemindersListInput.swift */,
 				7CE36AEF2FDEB28C0081E142 /* DeleteRemindersListInput.swift */,
 				7C8CC2FC2FDD4FFE008D1AB7 /* CreateRemindersListInput.swift */,
@@ -556,6 +559,7 @@
 				7C8CC2FD2FDD5007008D1AB7 /* CreateRemindersListInput.swift in Sources */,
 				7C265CDC2EA98E62005E867C /* CalendarPermissionScope.swift in Sources */,
 				7C265CDD2EA98E62005E867C /* GetReminderByIdInput.swift in Sources */,
+				7C0DEF022FDF210100A864E4 /* GetDefaultCalendarInput.swift in Sources */,
 				7CABD3812FDF141300A864E4 /* UpdateRemindersListInput.swift in Sources */,
 				7C265CDE2EA98E62005E867C /* RequestPermissionResult.swift in Sources */,
 				7C265CDF2EA98E62005E867C /* JSResult.swift in Sources */,

--- a/ios/Plugin/CapacitorCalendarPlugin.swift
+++ b/ios/Plugin/CapacitorCalendarPlugin.swift
@@ -212,11 +212,13 @@ public class CapacitorCalendarPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     @objc public func getDefaultCalendar(_ call: CAPPluginCall) {
-        do {
-            let result = try implementation.getDefaultCalendar()
-            resolveCall(call, result)
-        } catch let error {
-            rejectCall(call, error)
+        let input = GetDefaultCalendarInput(call: call)
+        implementation.getDefaultCalendar(input: input) { result, error in
+            if let error {
+                self.rejectCall(call, error)
+                return
+            }
+            self.resolveCall(call, result)
         }
     }
 

--- a/ios/Plugin/Implementation/CapacitorCalendar.swift
+++ b/ios/Plugin/Implementation/CapacitorCalendar.swift
@@ -345,8 +345,19 @@ class CapacitorCalendar: NSObject {
         return try CreateCalendarResult(id: newCalendar.calendarIdentifier)
     }
 
-    func getDefaultCalendar() throws -> GetDefaultCalendarResult {
-        return GetDefaultCalendarResult(calendar: eventStore.defaultCalendarForNewEvents)
+    func getDefaultCalendar(
+        input: GetDefaultCalendarInput,
+        completion: @escaping (GetDefaultCalendarResult?, Error?) -> Void
+    ) {
+        if let calendar = eventStore.defaultCalendarForNewEvents {
+            completion(GetDefaultCalendarResult(calendar: calendar), nil)
+            return
+        }
+        if input.getUseFallbackCalendar() {
+            completion(GetDefaultCalendarResult(calendar: eventStore.calendars(for: .event).first), nil)
+            return
+        }
+        completion(GetDefaultCalendarResult(calendar: nil), nil)
     }
 
     func getDefaultRemindersList() throws -> GetDefaultCalendarResult {

--- a/ios/Plugin/Models/Inputs/GetDefaultCalendarInput.swift
+++ b/ios/Plugin/Models/Inputs/GetDefaultCalendarInput.swift
@@ -1,0 +1,13 @@
+import Capacitor
+
+struct GetDefaultCalendarInput {
+    private let useFallbackCalendar: Bool
+
+    init(call: CAPPluginCall) {
+        self.useFallbackCalendar = call.getBool("useFallbackCalendar", false)
+    }
+
+    func getUseFallbackCalendar() -> Bool {
+        return useFallbackCalendar
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import type { DeleteReminderWithPromptOptions } from './schemas/interfaces/delet
 import type { DeleteRemindersByIdOptions } from './schemas/interfaces/delete-reminders-by-id-options';
 import type { DeleteRemindersListOptions } from './schemas/interfaces/delete-reminders-list-options';
 import type { EventGuest } from './schemas/interfaces/event-guest';
+import type { GetDefaultCalendarOptions } from './schemas/interfaces/get-default-calendar-options';
 import type { GetReminderByIdOptions } from './schemas/interfaces/get-reminder-by-id-options';
 import type { GetRemindersFromListsOptions } from './schemas/interfaces/get-reminders-from-lists-options';
 import type { ListEventsInRangeOptions } from './schemas/interfaces/list-events-in-range-options';
@@ -83,6 +84,7 @@ export type {
   DeleteRemindersListOptions,
   EventEditAction,
   EventGuest,
+  GetDefaultCalendarOptions,
   GetReminderByIdOptions,
   GetRemindersFromListsOptions,
   ListEventsInRangeOptions,

--- a/src/schemas/interfaces/get-default-calendar-options.ts
+++ b/src/schemas/interfaces/get-default-calendar-options.ts
@@ -1,0 +1,13 @@
+/**
+ * @since 8.4.0
+ */
+export interface GetDefaultCalendarOptions {
+  /**
+   * When there is no system default calendar, use the first available calendar.
+   *
+   * @default false
+   * @platform Android, iOS
+   * @since 8.4.0
+   */
+  useFallbackCalendar?: boolean;
+}

--- a/src/sub-definitions/calendar-operations.ts
+++ b/src/sub-definitions/calendar-operations.ts
@@ -2,6 +2,7 @@ import type { Calendar } from '../schemas/interfaces/calendar';
 import type { CalendarSource } from '../schemas/interfaces/calendar-source';
 import type { CreateCalendarOptions } from '../schemas/interfaces/create-calendar-options';
 import type { DeleteCalendarOptions } from '../schemas/interfaces/delete-calendar-options';
+import type { GetDefaultCalendarOptions } from '../schemas/interfaces/get-default-calendar-options';
 import type { ModifyCalendarOptions } from '../schemas/interfaces/modify-calendar-options';
 import type { OpenCalendarOptions } from '../schemas/interfaces/open-calendar-options';
 import type { SelectCalendarsWithPromptOptions } from '../schemas/interfaces/select-calendars-with-prompt-options';
@@ -45,13 +46,15 @@ export interface CalendarOperations {
   /**
    * Retrieves the default calendar.
    *
-   * On Android, the default calendar is the primary calendar when one is set;
-   * otherwise the first available calendar.
+   * The system default is the primary calendar on Android and
+   * `defaultCalendarForNewEvents` on iOS. When neither exists and
+   * `useFallbackCalendar` is true, the first available calendar is returned.
+   * Otherwise the method returns `null` when there is no system default.
    *
    * @platform Android, iOS
    * @since 0.3.0
    */
-  getDefaultCalendar(): Promise<{ result: Calendar | null }>;
+  getDefaultCalendar(options?: GetDefaultCalendarOptions): Promise<{ result: Calendar | null }>;
   /**
    * Opens the calendar app.
    *

--- a/src/sub-definitions/calendar-operations.ts
+++ b/src/sub-definitions/calendar-operations.ts
@@ -45,6 +45,9 @@ export interface CalendarOperations {
   /**
    * Retrieves the default calendar.
    *
+   * On Android, the default calendar is the primary calendar when one is set;
+   * otherwise the first available calendar.
+   *
    * @platform Android, iOS
    * @since 0.3.0
    */

--- a/src/web.ts
+++ b/src/web.ts
@@ -20,6 +20,7 @@ import type { DeleteReminderOptions } from './schemas/interfaces/delete-reminder
 import type { DeleteReminderWithPromptOptions } from './schemas/interfaces/delete-reminder-with-prompt-options';
 import type { DeleteRemindersByIdOptions } from './schemas/interfaces/delete-reminders-by-id-options';
 import type { DeleteRemindersListOptions } from './schemas/interfaces/delete-reminders-list-options';
+import type { GetDefaultCalendarOptions } from './schemas/interfaces/get-default-calendar-options';
 import type { GetReminderByIdOptions } from './schemas/interfaces/get-reminder-by-id-options';
 import type { GetRemindersFromListsOptions } from './schemas/interfaces/get-reminders-from-lists-options';
 import type { ListEventsInRangeOptions } from './schemas/interfaces/list-events-in-range-options';
@@ -125,7 +126,7 @@ export class CapacitorCalendarWeb extends WebPlugin implements CapacitorCalendar
     return this.throwUnimplemented(this.fetchAllRemindersSources.name);
   }
 
-  public getDefaultCalendar(): Promise<{ result: Calendar | null }> {
+  public getDefaultCalendar(_options?: GetDefaultCalendarOptions): Promise<{ result: Calendar | null }> {
     return this.throwUnimplemented(this.getDefaultCalendar.name);
   }
 


### PR DESCRIPTION
## Summary
- Add optional `GetDefaultCalendarOptions.useFallbackCalendar` (default `false`) so callers can fall back to the first available calendar when there is no system default
- Align Android and iOS selection: system default (primary / `defaultCalendarForNewEvents`), then first available when the option is true, otherwise `null`
- Keep `createEvent` without `calendarId` on its existing always-fallback path; wire native methods with shared completion/`resolveCall` helpers

## Test plan
- [ ] Call `getDefaultCalendar()` with no options — expect system default or `null` (no forced fallback)
- [ ] Call `getDefaultCalendar({ useFallbackCalendar: true })` with no primary / no `defaultCalendarForNewEvents` but other calendars present — expect first available
- [ ] Same call with no calendars at all — expect `null`
- [ ] Create an event without `calendarId` on Android — still uses primary-then-first fallback
- [ ] Exercise the example-app "Get default calendar" button and confirm both option paths log correctly

Closes: #243