### PR TITLE
fix: normalize Calendar.color hex format and nullability

### DIFF
--- a/.agents/skills/update-changelog/SKILL.md
+++ b/.agents/skills/update-changelog/SKILL.md
@@ -19,11 +19,12 @@ metadata:
 
 1. Read `package.json` and determine the current package version
 2. Decide if a version bump is needed:
-  If the version has already been raised, check the releases on GitHub. If there are no releases for this branch, the current version is the planned release version and doesn't need changing.
+   If the version has already been raised, check the releases on GitHub. If there are no releases for this branch, the current version is the planned release version and doesn't need changing.
 3. If the version has not been raised, ask what the release is (patch/minor/major), then run:
-  - patch: `npm run version:patch`
-  - minor: `npm run version:minor`
-  - major: `npm run version:major`
+
+- patch: `npm run version:patch`
+- minor: `npm run version:minor`
+- major: `npm run version:major`
 
 ## 2. Identify changes
 
@@ -34,15 +35,18 @@ metadata:
 ## 3. Update the changelog
 
 1. Run `cat CHANGELOG.md | grep <new_version>` to see if the new version already has a section
-  - If not, add it to the content table and create a section for the new version
+
+- If not, add it to the content table and create a section for the new version
+
 2. If the current version section already exists, reuse the existing section and add only missing changelog-worthy changes (do not duplicate existing entries)
 3. Use these categories to describe the changes:
-  - Added: new features
-  - Changed: changes in existing functionality
-  - Deprecated: soon-to-be removed features
-  - Removed: now removed features
-  - Fixed: any bug fixes
-  - Security: in case of vulnerabilities
+
+- Added: new features
+- Changed: changes in existing functionality
+- Deprecated: soon-to-be removed features
+- Removed: now removed features
+- Fixed: any bug fixes
+- Security: in case of vulnerabilities
 
 ## Rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Changelogs for the versions supporting Capacitor 8.
 - `CheckPermissionOptions` for `checkPermission(...)`
 - `RequestPermissionOptions` for `requestPermission(...)`
 - `SelectCalendarsWithPromptResult` for `selectCalendarsWithPrompt(...)`
+- `ListCalendarsResult` for `listCalendars(...)`
 - `GetDefaultCalendarOptions.useFallbackCalendar` for `getDefaultCalendar(...)` (when true, falls back to the first available calendar if there is no system default on Android and iOS)
 
 ### Fixed
@@ -63,11 +64,14 @@ Changelogs for the versions supporting Capacitor 8.
 - Android `requestAllPermissions()` now reports `readCalendar` from the read permission state (aligned with `checkAllPermissions()`)
 - Android `requestPermission(...)` distinguishes a missing scope (`Scope must be provided.`) from an invalid scope (`Invalid scope.`)
 - Android `deleteCalendar(...)` for calendars created via `createCalendar(...)` (sync-adapter URI)
+- Android calendar color reads emit `#RRGGBB` / `#RRGGBBAA` (aligned with iOS; was `#AARRGGBB`)
+- Android 8-digit hex color inputs parse as RRGGBBAA (aligned with iOS)
 
 ### Changed
 
 - `OpenCalendarOptions.date` is optional and documented as milliseconds since the epoch (defaults to now)
 - Documented platform limits for calendar permission request methods
+- `Calendar.title` and `Calendar.color` are `string | null` (matching runtime nullability)
 
 ## 8.3.0
 

--- a/README.md
+++ b/README.md
@@ -659,12 +659,12 @@ Retrieves a list of calendar sources.
 ### listCalendars()
 
 ```typescript
-listCalendars() => Promise<{ result: Calendar[]; }>
+listCalendars() => Promise<ListCalendarsResult>
 ```
 
 Retrieves a list of all available calendars.
 
-**Returns:** <code>Promise&lt;{ result: Calendar[]; }&gt;</code>
+**Returns:** <code>Promise&lt;<a href="#listcalendarsresult">ListCalendarsResult</a>&gt;</code>
 
 **Since:** 7.1.0
 
@@ -1222,22 +1222,22 @@ Options for {@link CalendarAccess#requestPermission}.
 
 #### Calendar
 
-| Prop                             | Type                                                              | Description                                                        | Since | Platform     |
-| -------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------ | ----- | ------------ |
-| **`id`**                         | <code>string</code>                                               |                                                                    | 7.1.0 | Android, iOS |
-| **`title`**                      | <code>string</code>                                               |                                                                    | 7.1.0 | Android, iOS |
-| **`internalTitle`**              | <code>string \| null</code>                                       | Internal name of the calendar (`CalendarContract.Calendars.NAME`). | 7.1.0 | Android      |
-| **`color`**                      | <code>string</code>                                               |                                                                    | 7.1.0 | Android, iOS |
-| **`isImmutable`**                | <code>boolean \| null</code>                                      |                                                                    | 7.1.0 | iOS          |
-| **`allowsContentModifications`** | <code>boolean \| null</code>                                      |                                                                    | 7.1.0 | iOS          |
-| **`type`**                       | <code><a href="#calendartype">CalendarType</a> \| null</code>     |                                                                    | 7.1.0 | iOS          |
-| **`isSubscribed`**               | <code>boolean \| null</code>                                      |                                                                    | 7.1.0 | iOS          |
-| **`source`**                     | <code><a href="#calendarsource">CalendarSource</a> \| null</code> |                                                                    | 7.1.0 | iOS          |
-| **`visible`**                    | <code>boolean \| null</code>                                      | Indicates if the events from this calendar should be shown.        | 7.1.0 | Android      |
-| **`accountName`**                | <code>string \| null</code>                                       | The account under which the calendar is registered.                | 7.1.0 | Android      |
-| **`ownerAccount`**               | <code>string \| null</code>                                       | The owner of the calendar.                                         | 7.1.0 | Android      |
-| **`maxReminders`**               | <code>number \| null</code>                                       | Maximum number of reminders allowed per event.                     | 7.1.0 | Android      |
-| **`location`**                   | <code>string \| null</code>                                       |                                                                    | 7.1.0 | Android      |
+| Prop                             | Type                                                              | Description                                                                                                                                                                                    | Since | Platform     |
+| -------------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ------------ |
+| **`id`**                         | <code>string</code>                                               |                                                                                                                                                                                                | 7.1.0 | Android, iOS |
+| **`title`**                      | <code>string \| null</code>                                       | Display title of the calendar. May be `null` when the platform does not provide a title.                                                                                                       | 7.1.0 | Android, iOS |
+| **`internalTitle`**              | <code>string \| null</code>                                       | Internal name of the calendar (`CalendarContract.Calendars.NAME`).                                                                                                                             | 7.1.0 | Android      |
+| **`color`**                      | <code>string \| null</code>                                       | <a href="#calendar">Calendar</a> color as a hex string. Format: `#RRGGBB` when opaque; `#RRGGBBAA` when alpha is below fully opaque. May be `null` when the platform does not provide a color. | 7.1.0 | Android, iOS |
+| **`isImmutable`**                | <code>boolean \| null</code>                                      |                                                                                                                                                                                                | 7.1.0 | iOS          |
+| **`allowsContentModifications`** | <code>boolean \| null</code>                                      |                                                                                                                                                                                                | 7.1.0 | iOS          |
+| **`type`**                       | <code><a href="#calendartype">CalendarType</a> \| null</code>     |                                                                                                                                                                                                | 7.1.0 | iOS          |
+| **`isSubscribed`**               | <code>boolean \| null</code>                                      |                                                                                                                                                                                                | 7.1.0 | iOS          |
+| **`source`**                     | <code><a href="#calendarsource">CalendarSource</a> \| null</code> |                                                                                                                                                                                                | 7.1.0 | iOS          |
+| **`visible`**                    | <code>boolean \| null</code>                                      | Indicates if the events from this calendar should be shown.                                                                                                                                    | 7.1.0 | Android      |
+| **`accountName`**                | <code>string \| null</code>                                       | The account under which the calendar is registered.                                                                                                                                            | 7.1.0 | Android      |
+| **`ownerAccount`**               | <code>string \| null</code>                                       | The owner of the calendar.                                                                                                                                                                     | 7.1.0 | Android      |
+| **`maxReminders`**               | <code>number \| null</code>                                       | Maximum number of reminders allowed per event.                                                                                                                                                 | 7.1.0 | Android      |
+| **`location`**                   | <code>string \| null</code>                                       |                                                                                                                                                                                                | 7.1.0 | Android      |
 
 #### CalendarSource
 
@@ -1253,6 +1253,12 @@ Options for {@link CalendarAccess#requestPermission}.
 | ------------------ | ----------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------ | ----- |
 | **`displayStyle`** | <code><a href="#calendarchooserdisplaystyle">CalendarChooserDisplayStyle</a></code> |                            | <code>CalendarChooserDisplayStyle.ALL_CALENDARS</code> | 7.1.0 |
 | **`multiple`**     | <code>boolean</code>                                                                | Allow multiple selections. | <code>false</code>                                     | 7.1.0 |
+
+#### ListCalendarsResult
+
+| Prop         | Type                    | Description              | Since | Platform     |
+| ------------ | ----------------------- | ------------------------ | ----- | ------------ |
+| **`result`** | <code>Calendar[]</code> | All available calendars. | 8.4.0 | Android, iOS |
 
 #### GetDefaultCalendarOptions
 

--- a/android/src/main/java/dev/barooni/capacitor/calendar/CapacitorCalendarPlugin.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/CapacitorCalendarPlugin.kt
@@ -286,13 +286,18 @@ class CapacitorCalendarPlugin : Plugin() {
         call.unimplemented(PluginError.Unimplemented(::fetchAllCalendarSources.name).message)
     }
 
-    @PluginMethod
+    @PluginMethod(returnType = PluginMethod.RETURN_PROMISE)
     fun listCalendars(call: PluginCall) {
         try {
-            val result = implementation.listCalendars()
-            call.resolve(result.toJSON())
+            implementation.listCalendars { result, error ->
+                if (error != null) {
+                    rejectCall(call, error)
+                    return@listCalendars
+                }
+                resolveCall(call, result)
+            }
         } catch (error: Exception) {
-            call.reject(error.message)
+            rejectCall(call, error)
         }
     }
 

--- a/android/src/main/java/dev/barooni/capacitor/calendar/PluginError.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/PluginError.kt
@@ -29,6 +29,8 @@ sealed class PluginError(
 
     data object ColorMissing : PluginError("Color must be provided.")
 
+    data object InvalidColor : PluginError("Invalid color format.")
+
     data object AccountNameMissing : PluginError("Account name must be provided.")
 
     data object OwnerAccountMissing : PluginError("Owner account must be provided.")

--- a/android/src/main/java/dev/barooni/capacitor/calendar/implementation/CapacitorCalendar.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/implementation/CapacitorCalendar.kt
@@ -140,10 +140,14 @@ class CapacitorCalendar(
         }
     }
 
-    fun listCalendars(): ListCalendarsResult {
-        val cr = plugin.context.contentResolver
-        val calendars = ImplementationHelper.listCalendars(cr)
-        return ListCalendarsResult(calendars)
+    fun listCalendars(completion: PluginCompletion<ListCalendarsResult>) {
+        try {
+            val cr = plugin.context.contentResolver
+            val calendars = ImplementationHelper.listCalendars(cr)
+            completion(ListCalendarsResult(calendars), null)
+        } catch (error: Exception) {
+            completion(null, error)
+        }
     }
 
     fun getDefaultCalendar(

--- a/android/src/main/java/dev/barooni/capacitor/calendar/models/inputs/GetDefaultCalendarInput.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/models/inputs/GetDefaultCalendarInput.kt
@@ -5,5 +5,5 @@ import com.getcapacitor.PluginCall
 data class GetDefaultCalendarInput(
     private val call: PluginCall,
 ) {
-    val useFallbackCalendar: Boolean = call.getBoolean("useFallbackCalendar", false)
+    val useFallbackCalendar: Boolean = call.getBoolean("useFallbackCalendar", false) ?: false
 }

--- a/android/src/main/java/dev/barooni/capacitor/calendar/utils/ImplementationHelper.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/utils/ImplementationHelper.kt
@@ -43,14 +43,56 @@ class ImplementationHelper {
             return list.map { it.toLongOrNull() ?: throw PluginError.MissingId }
         }
 
-        fun hexToColorInt(hex: String?): Int? =
+        fun hexToColorInt(hex: String?): Int? {
             if (hex == null) {
-                null
-            } else {
-                android.graphics.Color.parseColor(hex)
+                return null
             }
 
-        fun intToHexColor(colorInt: Int): String = String.format("#%08X", colorInt)
+            if (!hex.startsWith("#")) {
+                throw PluginError.InvalidColor
+            }
+
+            val digits = hex.substring(1)
+            return when (digits.length) {
+                6 -> {
+                    // RRGGBB with fully opaque alpha — Color.parseColor is correct for 6-digit.
+                    try {
+                        android.graphics.Color.parseColor(hex)
+                    } catch (_: IllegalArgumentException) {
+                        throw PluginError.InvalidColor
+                    }
+                }
+
+                8 -> {
+                    // RRGGBBAA (not AARRGGBB). Do not use Color.parseColor for 8-digit.
+                    try {
+                        val r = digits.substring(0, 2).toInt(16)
+                        val g = digits.substring(2, 4).toInt(16)
+                        val b = digits.substring(4, 6).toInt(16)
+                        val a = digits.substring(6, 8).toInt(16)
+                        android.graphics.Color.argb(a, r, g, b)
+                    } catch (_: NumberFormatException) {
+                        throw PluginError.InvalidColor
+                    }
+                }
+
+                else -> {
+                    throw PluginError.InvalidColor
+                }
+            }
+        }
+
+        fun intToHexColor(colorInt: Int): String {
+            val alpha = android.graphics.Color.alpha(colorInt)
+            val red = android.graphics.Color.red(colorInt)
+            val green = android.graphics.Color.green(colorInt)
+            val blue = android.graphics.Color.blue(colorInt)
+            return if (alpha == 0xFF) {
+                String.format(Locale.US, "#%02X%02X%02X", red, green, blue)
+            } else {
+                String.format(Locale.US, "#%02X%02X%02X%02X", red, green, blue, alpha)
+            }
+        }
 
         fun eventGuestsFromCall(call: PluginCall): List<EventGuest>? {
             val attendeesJson = call.getArray("attendees") ?: return null

--- a/example-app/src/css/example.css
+++ b/example-app/src/css/example.css
@@ -1,0 +1,18 @@
+#calendar-color-swatch {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid var(--ion-color-medium);
+  margin-inline-end: 12px;
+  align-self: center;
+  flex-shrink: 0;
+  background:
+    linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%);
+  background-size: 8px 8px;
+  background-position:
+    0 0,
+    0 4px,
+    4px -4px,
+    -4px 0;
+}

--- a/example-app/src/index.html
+++ b/example-app/src/index.html
@@ -23,6 +23,7 @@
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.esm.js"></script>
     <script nomodule src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core/css/ionic.bundle.css" />
+    <link rel="stylesheet" href="./css/example.css" />
 
     <script type="module" src="./js/example.js"></script>
   </head>
@@ -78,6 +79,28 @@
             helper-text="The identifier of the calendar to use"
           >
           </ion-input>
+        </ion-item>
+        <ion-item lines="none" class="ion-no-padding">
+          <div slot="start" id="calendar-color-swatch" aria-hidden="true"></div>
+          <ion-select
+            id="calendar-color-select"
+            label="Calendar color"
+            label-placement="stacked"
+            interface="popover"
+            value="#0000FF"
+            helper-text="Hex for create/modify calendar and create event. Valid: #RRGGBB or #RRGGBBAA."
+          >
+            <ion-select-option value="#0000FF">Blue — #0000FF (valid)</ion-select-option>
+            <ion-select-option value="#FF0000">Red — #FF0000 (valid)</ion-select-option>
+            <ion-select-option value="#00FF0080">Green 50% — #00FF0080 (valid)</ion-select-option>
+            <ion-select-option value="#0000ff">Blue lowercase — #0000ff (valid)</ion-select-option>
+            <ion-select-option value="#6750A4">Purple — #6750A4 (valid)</ion-select-option>
+            <ion-select-option value="0000FF">Missing # — 0000FF (invalid)</ion-select-option>
+            <ion-select-option value="#F00">Too short — #F00 (invalid)</ion-select-option>
+            <ion-select-option value="#FF0000FF00">Too long — #FF0000FF00 (invalid)</ion-select-option>
+            <ion-select-option value="#ZZ0000">Non-hex — #ZZ0000 (invalid)</ion-select-option>
+            <ion-select-option value="blue">Named color — blue (invalid)</ion-select-option>
+          </ion-select>
         </ion-item>
         <ion-item lines="none" class="ion-no-padding">
           <ion-input

--- a/example-app/src/js/example.js
+++ b/example-app/src/js/example.js
@@ -1,15 +1,22 @@
 import { CapacitorCalendar, EventAvailability, EventSpan } from '@ebarooni/capacitor-calendar';
 
 document.addEventListener('DOMContentLoaded', () => {
+  const calendarColorSelect = document.querySelector('#calendar-color-select');
+  updateCalendarColorSwatch(calendarColorSelect.value);
+  calendarColorSelect.addEventListener('ionChange', (event) => {
+    updateCalendarColorSwatch(event.detail.value);
+  });
+
   document.querySelector('#check-all-permissions').addEventListener('click', async () => {
     const result = await CapacitorCalendar.checkAllPermissions();
     console.log('#checkAllPermissions', result);
   });
 
   document.querySelector('#create-calendar').addEventListener('click', async () => {
+    const color = getCalendarColor();
     const result = await CapacitorCalendar.createCalendar({
       accountName: 'plugin@example.com',
-      color: '#6750A4',
+      color,
       ownerAccount: 'plugin@example.com',
       title: 'Plugin Test Calendar',
     });
@@ -23,13 +30,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const startDate = Date.now();
     const endDate = startDate + 60 * 60 * 1000;
     const recurrenceEnd = startDate + 14 * 24 * 60 * 60 * 1000;
+    const color = getCalendarColor();
 
     const result = await CapacitorCalendar.createEvent({
       alerts: [-1440, -60, 30],
       attendees: [{ email: 'guest@example.com', name: 'Alex Guest' }],
       availability: EventAvailability.BUSY,
       calendarId: pickNonHolidayCalendar(calendars)?.id,
-      color: '#6750A4',
+      color,
       commit: true,
       description: 'Created with @ebarooni/capacitor-calendar',
       endDate,
@@ -169,8 +177,9 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   document.querySelector('#modify-calendar').addEventListener('click', async () => {
+    const color = getCalendarColor();
     await CapacitorCalendar.modifyCalendar({
-      color: '#B3261E',
+      color,
       id: getCalendarIdInput().value,
       title: 'Updated Plugin Test Calendar',
     });
@@ -216,8 +225,43 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 });
 
+function getCalendarColor() {
+  return document.querySelector('#calendar-color-select').value;
+}
+
 function getCalendarIdInput() {
   return document.querySelector('#calendar-id-input');
+}
+
+function updateCalendarColorSwatch(hex) {
+  const swatch = document.querySelector('#calendar-color-swatch');
+  const preview = cssColorPreview(hex);
+  if (preview) {
+    swatch.style.background = preview;
+    swatch.title = hex;
+  } else {
+    swatch.style.background = '';
+    swatch.title = `${hex} (no CSS preview)`;
+  }
+}
+
+/** Map plugin hex (#RRGGBB / #RRGGBBAA) to a CSS color for the swatch; null if not previewable. */
+function cssColorPreview(hex) {
+  if (typeof hex !== 'string' || !hex.startsWith('#')) {
+    return null;
+  }
+  const digits = hex.slice(1);
+  if (/^[0-9a-fA-F]{6}$/.test(digits)) {
+    return `#${digits}`;
+  }
+  if (/^[0-9a-fA-F]{8}$/.test(digits)) {
+    const r = digits.slice(0, 2);
+    const g = digits.slice(2, 4);
+    const b = digits.slice(4, 6);
+    const a = Number.parseInt(digits.slice(6, 8), 16) / 255;
+    return `rgba(${Number.parseInt(r, 16)}, ${Number.parseInt(g, 16)}, ${Number.parseInt(b, 16)}, ${a})`;
+  }
+  return null;
 }
 
 function getEventIdInput() {

--- a/ios/Plugin/CapacitorCalendarPlugin.swift
+++ b/ios/Plugin/CapacitorCalendarPlugin.swift
@@ -189,10 +189,12 @@ public class CapacitorCalendarPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     @objc public func listCalendars(_ call: CAPPluginCall) {
-        do {
-            resolveCall(call, try implementation.listCalendars())
-        } catch let error {
-            rejectCall(call, error)
+        implementation.listCalendars { result, error in
+            if let error {
+                self.rejectCall(call, error)
+                return
+            }
+            self.resolveCall(call, result)
         }
     }
 

--- a/ios/Plugin/Implementation/CapacitorCalendar.swift
+++ b/ios/Plugin/Implementation/CapacitorCalendar.swift
@@ -309,8 +309,8 @@ class CapacitorCalendar: NSObject {
         return FetchAllCalendarSourcesResult(eventStore.sources)
     }
 
-    func listCalendars() throws -> ListCalendarsResult {
-        return ListCalendarsResult(eventStore.calendars(for: .event))
+    func listCalendars(completion: @escaping (ListCalendarsResult?, Error?) -> Void) {
+        completion(ListCalendarsResult(eventStore.calendars(for: .event)), nil)
     }
 
     func openReminders() async throws {

--- a/ios/Plugin/Utils/ImplementationHelper.swift
+++ b/ios/Plugin/Utils/ImplementationHelper.swift
@@ -107,23 +107,23 @@ struct ImplementationHelper {
         guard let components = color.components else { return nil }
 
         if components.count == 2 {
-            let gray = Float(components[0])
-            let alpha = Float(components[1])
-            return alpha < 1.0
-                ? String(format: "#%02lX%02lX%02lX%02lX", lroundf(gray * 255), lroundf(gray * 255), lroundf(gray * 255), lroundf(alpha * 255))
-                : String(format: "#%02lX%02lX%02lX", lroundf(gray * 255), lroundf(gray * 255), lroundf(gray * 255))
+            let gray = lroundf(Float(components[0]) * 255)
+            let alpha = lroundf(Float(components[1]) * 255)
+            return alpha == 255
+                ? String(format: "#%02lX%02lX%02lX", gray, gray, gray)
+                : String(format: "#%02lX%02lX%02lX%02lX", gray, gray, gray, alpha)
         }
 
         guard components.count >= 3 else { return nil }
 
-        let red = Float(components[0])
-        let green = Float(components[1])
-        let blue = Float(components[2])
-        let alpha = components.count == 4 ? Float(components[3]) : 1.0
+        let red = lroundf(Float(components[0]) * 255)
+        let green = lroundf(Float(components[1]) * 255)
+        let blue = lroundf(Float(components[2]) * 255)
+        let alpha = components.count == 4 ? lroundf(Float(components[3]) * 255) : 255
 
-        return alpha < 1.0
-            ? String(format: "#%02lX%02lX%02lX%02lX", lroundf(red * 255), lroundf(green * 255), lroundf(blue * 255), lroundf(alpha * 255))
-            : String(format: "#%02lX%02lX%02lX", lroundf(red * 255), lroundf(green * 255), lroundf(blue * 255))
+        return alpha == 255
+            ? String(format: "#%02lX%02lX%02lX", red, green, blue)
+            : String(format: "#%02lX%02lX%02lX%02lX", red, green, blue, alpha)
     }
 
     static func deleteReminder(reminderId: String, eventStore: EKEventStore) throws {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import type { EventGuest } from './schemas/interfaces/event-guest';
 import type { GetDefaultCalendarOptions } from './schemas/interfaces/get-default-calendar-options';
 import type { GetReminderByIdOptions } from './schemas/interfaces/get-reminder-by-id-options';
 import type { GetRemindersFromListsOptions } from './schemas/interfaces/get-reminders-from-lists-options';
+import type { ListCalendarsResult } from './schemas/interfaces/list-calendars-result';
 import type { ListEventsInRangeOptions } from './schemas/interfaces/list-events-in-range-options';
 import type { ModifyCalendarOptions } from './schemas/interfaces/modify-calendar-options';
 import type { ModifyEventOptions } from './schemas/interfaces/modify-event-options';
@@ -87,6 +88,7 @@ export type {
   GetDefaultCalendarOptions,
   GetReminderByIdOptions,
   GetRemindersFromListsOptions,
+  ListCalendarsResult,
   ListEventsInRangeOptions,
   ModifyCalendarOptions,
   ModifyEventOptions,

--- a/src/schemas/interfaces/calendar.ts
+++ b/src/schemas/interfaces/calendar.ts
@@ -12,10 +12,13 @@ export interface Calendar {
    */
   id: string;
   /**
+   * Display title of the calendar.
+   * May be `null` when the platform does not provide a title.
+   *
    * @platform Android, iOS
    * @since 7.1.0
    */
-  title: string;
+  title: string | null;
   /**
    * Internal name of the calendar (`CalendarContract.Calendars.NAME`).
    *
@@ -24,10 +27,17 @@ export interface Calendar {
    */
   internalTitle: string | null;
   /**
+   * Calendar color as a hex string.
+   *
+   * Format: `#RRGGBB` when opaque; `#RRGGBBAA` when alpha is below fully opaque.
+   * May be `null` when the platform does not provide a color.
+   *
    * @platform Android, iOS
+   * @example #0000FF
+   * @example #0000FF80
    * @since 7.1.0
    */
-  color: string;
+  color: string | null;
   /**
    * @platform iOS
    * @since 7.1.0

--- a/src/schemas/interfaces/list-calendars-result.ts
+++ b/src/schemas/interfaces/list-calendars-result.ts
@@ -1,0 +1,14 @@
+import type { Calendar } from './calendar';
+
+/**
+ * @since 8.4.0
+ */
+export interface ListCalendarsResult {
+  /**
+   * All available calendars.
+   *
+   * @platform Android, iOS
+   * @since 8.4.0
+   */
+  result: Calendar[];
+}

--- a/src/sub-definitions/calendar-operations.ts
+++ b/src/sub-definitions/calendar-operations.ts
@@ -3,6 +3,7 @@ import type { CalendarSource } from '../schemas/interfaces/calendar-source';
 import type { CreateCalendarOptions } from '../schemas/interfaces/create-calendar-options';
 import type { DeleteCalendarOptions } from '../schemas/interfaces/delete-calendar-options';
 import type { GetDefaultCalendarOptions } from '../schemas/interfaces/get-default-calendar-options';
+import type { ListCalendarsResult } from '../schemas/interfaces/list-calendars-result';
 import type { ModifyCalendarOptions } from '../schemas/interfaces/modify-calendar-options';
 import type { OpenCalendarOptions } from '../schemas/interfaces/open-calendar-options';
 import type { SelectCalendarsWithPromptOptions } from '../schemas/interfaces/select-calendars-with-prompt-options';
@@ -42,7 +43,7 @@ export interface CalendarOperations {
    * @platform Android, iOS
    * @since 7.1.0
    */
-  listCalendars(): Promise<{ result: Calendar[] }>;
+  listCalendars(): Promise<ListCalendarsResult>;
   /**
    * Retrieves the default calendar.
    *

--- a/src/web.ts
+++ b/src/web.ts
@@ -23,6 +23,7 @@ import type { DeleteRemindersListOptions } from './schemas/interfaces/delete-rem
 import type { GetDefaultCalendarOptions } from './schemas/interfaces/get-default-calendar-options';
 import type { GetReminderByIdOptions } from './schemas/interfaces/get-reminder-by-id-options';
 import type { GetRemindersFromListsOptions } from './schemas/interfaces/get-reminders-from-lists-options';
+import type { ListCalendarsResult } from './schemas/interfaces/list-calendars-result';
 import type { ListEventsInRangeOptions } from './schemas/interfaces/list-events-in-range-options';
 import type { ModifyCalendarOptions } from './schemas/interfaces/modify-calendar-options';
 import type { ModifyEventOptions } from './schemas/interfaces/modify-event-options';
@@ -118,7 +119,7 @@ export class CapacitorCalendarWeb extends WebPlugin implements CapacitorCalendar
     return this.throwUnimplemented(this.fetchAllCalendarSources.name);
   }
 
-  public listCalendars(): Promise<{ result: Calendar[] }> {
+  public listCalendars(): Promise<ListCalendarsResult> {
     return this.throwUnimplemented(this.listCalendars.name);
   }
 


### PR DESCRIPTION
## Summary
- Normalize calendar color strings to `#RRGGBB` / `#RRGGBBAA` on Android and iOS (reads and 8-digit inputs)
- Type `Calendar.title` and `Calendar.color` as `string | null`, and add `ListCalendarsResult` for `listCalendars`
- Add example-app color select (valid/invalid hex) for create/modify calendar and create event

## Test plan
- [ ] Create calendar with valid `#RRGGBB` / `#RRGGBBAA` / lowercase hex; confirm success
- [ ] Create calendar with invalid colors (missing `#`, wrong length, non-hex, named); confirm reject with invalid color format
- [ ] `listCalendars` / `getDefaultCalendar` return matching hex format on Android and iOS for the same opaque color
- [ ] Round-trip listed calendar color into modify calendar without channel swap

Closes: #244