### PR TITLE
docs: show monthly npm installs on the downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <img src="https://img.shields.io/npm/l/@ebarooni/capacitor-calendar?style=flat-square" />
   </a>
   <a href="https://www.npmjs.com/package/@ebarooni/capacitor-calendar">
-    <img src="https://img.shields.io/npm/dw/@ebarooni/capacitor-calendar?style=flat-square" />
+    <img src="https://img.shields.io/npm/dm/@ebarooni/capacitor-calendar?style=flat-square" />
   </a>
   <a href="https://www.npmjs.com/package/@ebarooni/capacitor-calendar">
     <img src="https://img.shields.io/npm/v/@ebarooni/capacitor-calendar?style=flat-square" />


### PR DESCRIPTION
## Summary
- Switch the npm downloads Shields.io badge from weekly (`npm/dw`) to monthly (`npm/dm`) in the README.

## Test plan
- [x] Confirm the README badge URL uses `npm/dm`
- [ ] Confirm the badge renders monthly installs on GitHub