### PR TITLE
fix: align calendar CRUD contract across Android and iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ Changelogs for the versions supporting Capacitor 8.
 - Android `deleteCalendar(...)` for calendars created via `createCalendar(...)` (sync-adapter URI)
 - Android calendar color reads emit `#RRGGBB` / `#RRGGBBAA` (aligned with iOS; was `#AARRGGBB`)
 - Android 8-digit hex color inputs parse as RRGGBBAA (aligned with iOS)
+- Android `createCalendar(...)` no longer requires `color`
+- `modifyCalendar(...)` with only `id` is rejected on Android and iOS
+- iOS `modifyCalendar(...)` rejects calendars that do not allow content modifications
+- Calendar missing-id errors no longer say `Event ID must be provided.`
 
 ### Changed
 
@@ -75,6 +79,10 @@ Changelogs for the versions supporting Capacitor 8.
 - Documented platform limits for calendar permission request methods
 - `Calendar.title` and `Calendar.color` are `string | null` (matching runtime nullability)
 - Documented permission and empty/null behavior for `listCalendars(...)`, `getDefaultCalendar(...)`, `fetchAllCalendarSources(...)`, and `selectCalendarsWithPrompt(...)`
+- `createCalendar(...)` `color` is optional on Android and iOS and defaults to `#007AFF`
+- iOS `createCalendar(...)` uses iCloud then local when `sourceId` is omitted; an unknown `sourceId` is rejected
+- Android `modifyCalendar(...)` updates both display name and internal name when `title` is set
+- Shared calendar CRUD errors: missing/invalid calendar id, calendar not found, invalid color, and modify with no fields
 
 ## 8.3.0
 

--- a/README.md
+++ b/README.md
@@ -735,6 +735,9 @@ createCalendar(options: CreateCalendarOptions) => Promise<CreateCalendarResult>
 
 Creates a calendar.
 
+`title` is required. `color` is optional and defaults to `#007AFF`.
+On Android, `accountName` and `ownerAccount` are required at runtime.
+
 | Param         | Type                                                                    |
 | ------------- | ----------------------------------------------------------------------- |
 | **`options`** | <code><a href="#createcalendaroptions">CreateCalendarOptions</a></code> |
@@ -772,6 +775,8 @@ modifyCalendar(options: ModifyCalendarOptions) => Promise<void>
 ```
 
 Modifies a calendar with options.
+
+At least one of `title` or `color` must be provided.
 
 | Param         | Type                                                                    |
 | ------------- | ----------------------------------------------------------------------- |
@@ -1298,27 +1303,27 @@ Options for {@link CalendarAccess#requestPermission}.
 
 #### CreateCalendarOptions
 
-| Prop               | Type                | Description                                                | Since | Platform     |
-| ------------------ | ------------------- | ---------------------------------------------------------- | ----- | ------------ |
-| **`title`**        | <code>string</code> |                                                            | 5.2.0 | Android, iOS |
-| **`color`**        | <code>string</code> | The color of the calendar. Should be provided on Android.  | 5.2.0 | Android, iOS |
-| **`sourceId`**     | <code>string</code> |                                                            | 5.2.0 | iOS          |
-| **`accountName`**  | <code>string</code> | Only needed on Android. Typically set to an email address. | 7.1.0 | Android      |
-| **`ownerAccount`** | <code>string</code> | Only needed on Android. Typically set to an email address. | 7.1.0 | Android      |
+| Prop               | Type                | Description                                                                                                                                                                                                                | Default              | Since | Platform     |
+| ------------------ | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ----- | ------------ |
+| **`title`**        | <code>string</code> |                                                                                                                                                                                                                            |                      | 5.2.0 | Android, iOS |
+| **`color`**        | <code>string</code> | The color of the calendar as `#RRGGBB` or `#RRGGBBAA`. When omitted, Android and iOS use `#007AFF` (light-mode iOS system blue).                                                                                           | <code>#007AFF</code> | 5.2.0 | Android, iOS |
+| **`sourceId`**     | <code>string</code> | The EventKit source (account) where the calendar should be created. If provided, it must match an existing source from `fetchAllCalendarSources()`. If omitted, iCloud is used when available, otherwise the local source. |                      | 5.2.0 | iOS          |
+| **`accountName`**  | <code>string</code> | The account under which the calendar is registered. Required on Android. Typically an email address.                                                                                                                       |                      | 7.1.0 | Android      |
+| **`ownerAccount`** | <code>string</code> | The owner of the calendar. Required on Android. Typically an email address.                                                                                                                                                |                      | 7.1.0 | Android      |
 
 #### DeleteCalendarOptions
 
-| Prop     | Type                | Since |
-| -------- | ------------------- | ----- |
-| **`id`** | <code>string</code> | 7.1.0 |
+| Prop     | Type                | Since | Platform     |
+| -------- | ------------------- | ----- | ------------ |
+| **`id`** | <code>string</code> | 7.1.0 | Android, iOS |
 
 #### ModifyCalendarOptions
 
-| Prop        | Type                | Since | Platform     |
-| ----------- | ------------------- | ----- | ------------ |
-| **`id`**    | <code>string</code> | 7.2.0 | Android, iOS |
-| **`title`** | <code>string</code> | 7.2.0 | Android, iOS |
-| **`color`** | <code>string</code> | 7.2.0 | Android, iOS |
+| Prop        | Type                | Description                                                                                                                                                                                | Since | Platform     |
+| ----------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- | ------------ |
+| **`id`**    | <code>string</code> |                                                                                                                                                                                            | 7.2.0 | Android, iOS |
+| **`title`** | <code>string</code> | Display title of the calendar. On Android this updates both `CALENDAR_DISPLAY_NAME` (`title`) and `Calendars.NAME` (`internalTitle`). At least one of `title` or `color` must be provided. | 7.2.0 | Android, iOS |
+| **`color`** | <code>string</code> | The color of the calendar as `#RRGGBB` or `#RRGGBBAA`. Omit to leave the color unchanged. At least one of `title` or `color` must be provided.                                             | 7.2.0 | Android, iOS
 
 #### CreateRemindersListResult
 

--- a/README.md
+++ b/README.md
@@ -776,8 +776,6 @@ modifyCalendar(options: ModifyCalendarOptions) => Promise<void>
 
 Modifies a calendar with options.
 
-At least one of `title` or `color` must be provided.
-
 | Param         | Type                                                                    |
 | ------------- | ----------------------------------------------------------------------- |
 | **`options`** | <code><a href="#modifycalendaroptions">ModifyCalendarOptions</a></code> |
@@ -1319,11 +1317,11 @@ Options for {@link CalendarAccess#requestPermission}.
 
 #### ModifyCalendarOptions
 
-| Prop        | Type                | Description                                                                                                                                                                                | Since | Platform     |
-| ----------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- | ------------ |
-| **`id`**    | <code>string</code> |                                                                                                                                                                                            | 7.2.0 | Android, iOS |
-| **`title`** | <code>string</code> | Display title of the calendar. On Android this updates both `CALENDAR_DISPLAY_NAME` (`title`) and `Calendars.NAME` (`internalTitle`). At least one of `title` or `color` must be provided. | 7.2.0 | Android, iOS |
-| **`color`** | <code>string</code> | The color of the calendar as `#RRGGBB` or `#RRGGBBAA`. Omit to leave the color unchanged. At least one of `title` or `color` must be provided.                                             | 7.2.0 | Android, iOS
+| Prop        | Type                | Description                                                                                                                           | Since | Platform     |
+| ----------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ----- | ------------ |
+| **`id`**    | <code>string</code> |                                                                                                                                       | 7.2.0 | Android, iOS |
+| **`title`** | <code>string</code> | Display title of the calendar. On Android this updates both `CALENDAR_DISPLAY_NAME` (`title`) and `Calendars.NAME` (`internalTitle`). | 7.2.0 | Android, iOS |
+| **`color`** | <code>string</code> | The color of the calendar as `#RRGGBB` or `#RRGGBBAA`.                                                                                | 7.2.0 | Android, iOS |
 
 #### CreateRemindersListResult
 

--- a/android/src/main/java/dev/barooni/capacitor/calendar/PluginError.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/PluginError.kt
@@ -47,11 +47,11 @@ sealed class PluginError(
 
     data object NoCalendarsAvailable : PluginError("No calendars available.")
 
+    data object NoFieldsToModify : PluginError("At least one of title or color must be provided.")
+
     data object OwnerAccountMissing : PluginError("Owner account must be provided.")
 
     data object TitleMissing : PluginError("Title must be provided.")
-
-    data object TitleOrColorMissing : PluginError("At least one of title or color must be provided.")
 
     data object ToDateMissing : PluginError("To date must be provided.")
 

--- a/android/src/main/java/dev/barooni/capacitor/calendar/PluginError.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/PluginError.kt
@@ -3,61 +3,61 @@ package dev.barooni.capacitor.calendar
 sealed class PluginError(
     localizedDescription: String,
 ) : Exception(localizedDescription) {
-    data object MissingScope : PluginError("Scope must be provided.")
+    data object AccountNameMissing : PluginError("Account name must be provided.")
 
-    data object InvalidScope : PluginError("Invalid scope.")
+    data object AttendeeEmailMissing : PluginError("Attendee email must be provided.")
 
-    data object UnhandledPermissionState : PluginError("Unhandled permission state.")
+    data object CalendarIdMissing : PluginError("Calendar ID must be provided.")
 
-    data object InvalidInvitees : PluginError("Invalid invitees. Array must contain only strings.")
+    data object CalendarNotFound : PluginError("Calendar not found.")
 
-    data object MissingId : PluginError("Event ID must be provided.")
+    data object ColorMissing : PluginError("Color must be provided.")
+
+    data class CustomError(
+        val details: String,
+    ) : PluginError(details)
+
+    data object FailedToDelete : PluginError("Failed to delete.")
+
+    data object FailedToModify : PluginError("Failed to modify.")
+
+    data object FailedToRetrieveCalendarId : PluginError("Failed to retrieve calendar ID.")
+
+    data object FailedToRetrieveEventId : PluginError("Failed to retrieve event ID.")
+
+    data object FromDateMissing : PluginError("From date must be provided.")
 
     data object InstanceDateMissing : PluginError(
         "Instance date must be provided for this span on recurring events.",
     )
 
-    data object TitleMissing : PluginError("Title must be provided.")
-
-    data object FailedToRetrieveEventId : PluginError("Failed to retrieve event ID.")
-
-    data object FailedToRetrieveCalendarId : PluginError("Failed to retrieve calendar ID.")
-
-    data object AttendeeEmailMissing : PluginError("Attendee email must be provided.")
-
-    data object NoCalendarsAvailable : PluginError("No calendars available.")
-
-    data object ColorMissing : PluginError("Color must be provided.")
+    data object InvalidCalendarId : PluginError("Invalid calendar ID.")
 
     data object InvalidColor : PluginError("Invalid color format.")
 
-    data object AccountNameMissing : PluginError("Account name must be provided.")
+    data object InvalidInvitees : PluginError("Invalid invitees. Array must contain only strings.")
 
-    data object OwnerAccountMissing : PluginError("Owner account must be provided.")
-
-    data object FailedToDelete : PluginError("Failed to delete.")
+    data object InvalidScope : PluginError("Invalid scope.")
 
     data object MessageMissing : PluginError("Message must be provided.")
 
-    data object FromDateMissing : PluginError("From date must be provided.")
+    data object MissingId : PluginError("Event ID must be provided.")
 
-    data object ToDateMissing : PluginError("To date must be provided.")
+    data object MissingScope : PluginError("Scope must be provided.")
 
-    data object FailedToModify : PluginError("Failed to modify.")
+    data object NoCalendarsAvailable : PluginError("No calendars available.")
 
-    data object CalendarIdMissing : PluginError("Calendar ID must be provided.")
+    data object OwnerAccountMissing : PluginError("Owner account must be provided.")
 
-    data object InvalidCalendarId : PluginError("Invalid calendar ID.")
+    data object TitleMissing : PluginError("Title must be provided.")
 
     data object TitleOrColorMissing : PluginError("At least one of title or color must be provided.")
 
-    data object CalendarNotFound : PluginError("Calendar not found.")
+    data object ToDateMissing : PluginError("To date must be provided.")
+
+    data object UnhandledPermissionState : PluginError("Unhandled permission state.")
 
     data class Unimplemented(
         val methodName: String,
     ) : PluginError("$methodName is not implemented on Android.")
-
-    data class CustomError(
-        val details: String,
-    ) : PluginError(details)
 }

--- a/android/src/main/java/dev/barooni/capacitor/calendar/PluginError.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/PluginError.kt
@@ -45,6 +45,14 @@ sealed class PluginError(
 
     data object FailedToModify : PluginError("Failed to modify.")
 
+    data object CalendarIdMissing : PluginError("Calendar ID must be provided.")
+
+    data object InvalidCalendarId : PluginError("Invalid calendar ID.")
+
+    data object TitleOrColorMissing : PluginError("At least one of title or color must be provided.")
+
+    data object CalendarNotFound : PluginError("Calendar not found.")
+
     data class Unimplemented(
         val methodName: String,
     ) : PluginError("$methodName is not implemented on Android.")

--- a/android/src/main/java/dev/barooni/capacitor/calendar/implementation/CapacitorCalendar.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/implementation/CapacitorCalendar.kt
@@ -213,16 +213,16 @@ class CapacitorCalendar(
         val (accountName, accountType) =
             cr.query(calendarUri, projection, null, null, null)?.use { cursor ->
                 if (!cursor.moveToFirst()) {
-                    throw PluginError.FailedToDelete
+                    throw PluginError.CalendarNotFound
                 }
                 val name =
                     cursor.getString(cursor.getColumnIndexOrThrow(CalendarContract.Calendars.ACCOUNT_NAME))
-                        ?: throw PluginError.FailedToDelete
+                        ?: throw PluginError.CalendarNotFound
                 val type =
                     cursor.getString(cursor.getColumnIndexOrThrow(CalendarContract.Calendars.ACCOUNT_TYPE))
-                        ?: throw PluginError.FailedToDelete
+                        ?: throw PluginError.CalendarNotFound
                 name to type
-            } ?: throw PluginError.FailedToDelete
+            } ?: throw PluginError.CalendarNotFound
 
         val deleteUri =
             calendarUri
@@ -234,7 +234,7 @@ class CapacitorCalendar(
 
         val rowsDeleted = cr.delete(deleteUri, null, null)
         if (rowsDeleted < 1) {
-            throw PluginError.FailedToDelete
+            throw PluginError.CalendarNotFound
         }
     }
 
@@ -444,13 +444,16 @@ class CapacitorCalendar(
         val cr = plugin.context.contentResolver
         val values =
             ContentValues().apply {
-                input.title?.let { put(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME, it) }
+                input.title?.let {
+                    put(CalendarContract.Calendars.NAME, it)
+                    put(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME, it)
+                }
                 input.color?.let { put(CalendarContract.Calendars.CALENDAR_COLOR, it) }
             }
         val uri: Uri = ContentUris.withAppendedId(CalendarContract.Calendars.CONTENT_URI, input.id)
         val rowsUpdated = cr.update(uri, values, null, null)
         if (rowsUpdated < 1) {
-            throw PluginError.FailedToModify
+            throw PluginError.CalendarNotFound
         }
     }
 }

--- a/android/src/main/java/dev/barooni/capacitor/calendar/models/inputs/CreateCalendarInput.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/models/inputs/CreateCalendarInput.kt
@@ -9,7 +9,9 @@ data class CreateCalendarInput(
     private val call: PluginCall,
 ) {
     val title = call.getString("title") ?: throw PluginError.TitleMissing
-    val color = call.getString("color").let { ImplementationHelper.hexToColorInt(it) } ?: throw PluginError.ColorMissing
+    val color =
+        ImplementationHelper.hexToColorInt(call.getString("color"))
+            ?: ImplementationHelper.DEFAULT_CALENDAR_COLOR
     val accountName = call.getString("accountName") ?: throw PluginError.AccountNameMissing
     val ownerAccount = call.getString("ownerAccount") ?: throw PluginError.OwnerAccountMissing
     val accountType = CalendarContract.ACCOUNT_TYPE_LOCAL

--- a/android/src/main/java/dev/barooni/capacitor/calendar/models/inputs/DeleteCalendarInput.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/models/inputs/DeleteCalendarInput.kt
@@ -6,5 +6,8 @@ import dev.barooni.capacitor.calendar.PluginError
 data class DeleteCalendarInput(
     private val call: PluginCall,
 ) {
-    val id = call.getString("id")?.toLong() ?: throw PluginError.MissingId
+    val id: Long =
+        call.getString("id")?.let { idString ->
+            idString.toLongOrNull() ?: throw PluginError.InvalidCalendarId
+        } ?: throw PluginError.CalendarIdMissing
 }

--- a/android/src/main/java/dev/barooni/capacitor/calendar/models/inputs/ModifyCalendarInput.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/models/inputs/ModifyCalendarInput.kt
@@ -7,7 +7,16 @@ import dev.barooni.capacitor.calendar.utils.ImplementationHelper
 data class ModifyCalendarInput(
     private val call: PluginCall,
 ) {
-    val id = call.getString("id")?.toLong() ?: throw PluginError.MissingId
+    val id: Long =
+        call.getString("id")?.let { idString ->
+            idString.toLongOrNull() ?: throw PluginError.InvalidCalendarId
+        } ?: throw PluginError.CalendarIdMissing
     val title = call.getString("title")
     val color = call.getString("color")?.let { ImplementationHelper.hexToColorInt(it) }
+
+    init {
+        if (title == null && color == null) {
+            throw PluginError.TitleOrColorMissing
+        }
+    }
 }

--- a/android/src/main/java/dev/barooni/capacitor/calendar/models/inputs/ModifyCalendarInput.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/models/inputs/ModifyCalendarInput.kt
@@ -16,7 +16,7 @@ data class ModifyCalendarInput(
 
     init {
         if (title == null && color == null) {
-            throw PluginError.TitleOrColorMissing
+            throw PluginError.NoFieldsToModify
         }
     }
 }

--- a/android/src/main/java/dev/barooni/capacitor/calendar/utils/ImplementationHelper.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/utils/ImplementationHelper.kt
@@ -18,6 +18,9 @@ import java.util.TimeZone
 
 class ImplementationHelper {
     companion object {
+        /** Default `CALENDAR_COLOR` when `color` is omitted: `#007AFF`, fully opaque. */
+        val DEFAULT_CALENDAR_COLOR: Int = 0xFF007AFF.toInt()
+
         fun getCalendarFromTimestamp(timestamp: Long?): Calendar =
             Calendar.getInstance().apply {
                 timeInMillis = timestamp ?: System.currentTimeMillis()

--- a/example-app/src/index.html
+++ b/example-app/src/index.html
@@ -87,9 +87,11 @@
             label="Calendar color"
             label-placement="stacked"
             interface="popover"
-            value="#0000FF"
-            helper-text="Hex for create/modify calendar and create event. Valid: #RRGGBB or #RRGGBBAA."
+            value=""
+            helper-text="Hex for create/modify calendar and create event. Choose Omit to leave color unset (createCalendar uses the plugin default)."
           >
+            <ion-select-option value="">Omit — do not pass color</ion-select-option>
+            <ion-select-option value="#007AFF">Blue — #007AFF (valid)</ion-select-option>
             <ion-select-option value="#0000FF">Blue — #0000FF (valid)</ion-select-option>
             <ion-select-option value="#FF0000">Red — #FF0000 (valid)</ion-select-option>
             <ion-select-option value="#00FF0080">Green 50% — #00FF0080 (valid)</ion-select-option>

--- a/example-app/src/js/example.js
+++ b/example-app/src/js/example.js
@@ -13,10 +13,8 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   document.querySelector('#create-calendar').addEventListener('click', async () => {
-    const color = getCalendarColor();
     const result = await CapacitorCalendar.createCalendar({
       accountName: 'plugin@example.com',
-      color,
       ownerAccount: 'plugin@example.com',
       title: 'Plugin Test Calendar',
     });

--- a/example-app/src/js/example.js
+++ b/example-app/src/js/example.js
@@ -15,6 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelector('#create-calendar').addEventListener('click', async () => {
     const result = await CapacitorCalendar.createCalendar({
       accountName: 'plugin@example.com',
+      ...optionalCalendarColor(),
       ownerAccount: 'plugin@example.com',
       title: 'Plugin Test Calendar',
     });
@@ -28,14 +29,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const startDate = Date.now();
     const endDate = startDate + 60 * 60 * 1000;
     const recurrenceEnd = startDate + 14 * 24 * 60 * 60 * 1000;
-    const color = getCalendarColor();
-
     const result = await CapacitorCalendar.createEvent({
       alerts: [-1440, -60, 30],
       attendees: [{ email: 'guest@example.com', name: 'Alex Guest' }],
       availability: EventAvailability.BUSY,
       calendarId: pickNonHolidayCalendar(calendars)?.id,
-      color,
+      ...optionalCalendarColor(),
       commit: true,
       description: 'Created with @ebarooni/capacitor-calendar',
       endDate,
@@ -175,9 +174,8 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   document.querySelector('#modify-calendar').addEventListener('click', async () => {
-    const color = getCalendarColor();
     await CapacitorCalendar.modifyCalendar({
-      color,
+      ...optionalCalendarColor(),
       id: getCalendarIdInput().value,
       title: 'Updated Plugin Test Calendar',
     });
@@ -227,12 +225,23 @@ function getCalendarColor() {
   return document.querySelector('#calendar-color-select').value;
 }
 
+/** Returns `{ color }` only when the select has a value; empty means omit the field. */
+function optionalCalendarColor() {
+  const color = getCalendarColor();
+  return color ? { color } : {};
+}
+
 function getCalendarIdInput() {
   return document.querySelector('#calendar-id-input');
 }
 
 function updateCalendarColorSwatch(hex) {
   const swatch = document.querySelector('#calendar-color-swatch');
+  if (!hex) {
+    swatch.style.background = '';
+    swatch.title = 'Color omitted (plugin default on create)';
+    return;
+  }
   const preview = cssColorPreview(hex);
   if (preview) {
     swatch.style.background = preview;

--- a/ios/Plugin/Implementation/CapacitorCalendar.swift
+++ b/ios/Plugin/Implementation/CapacitorCalendar.swift
@@ -339,8 +339,20 @@ class CapacitorCalendar: NSObject {
     func createCalendar(input: CreateCalendarInput) throws -> CreateCalendarResult {
         let newCalendar = EKCalendar(for: .event, eventStore: eventStore)
         newCalendar.title = input.getTitle()
-        newCalendar.cgColor = input.getColor() ?? eventStore.defaultCalendarForNewEvents?.cgColor
-        newCalendar.source = eventStore.sources.first(where: { $0.sourceIdentifier == input.getSourceId() }) ?? eventStore.defaultCalendarForNewEvents?.source
+        newCalendar.cgColor = input.getColor()
+
+        let sources = eventStore.sources
+        if let sourceId = input.getSourceId() {
+            guard let customSource = sources.first(where: { $0.sourceIdentifier == sourceId }) else {
+                throw PluginError.calendarSourceNotFound
+            }
+            newCalendar.source = customSource
+        } else if let iCloudSource = sources.first(where: { $0.sourceType == .calDAV && $0.title == "iCloud" }) {
+            newCalendar.source = iCloudSource
+        } else if let localSource = sources.first(where: { $0.sourceType == .local }) {
+            newCalendar.source = localSource
+        }
+
         try eventStore.saveCalendar(newCalendar, commit: true)
         return try CreateCalendarResult(id: newCalendar.calendarIdentifier)
     }
@@ -548,6 +560,9 @@ class CapacitorCalendar: NSObject {
     func modifyCalendar(_ input: ModifyCalendarInput) throws {
         guard let calendar = eventStore.calendar(withIdentifier: input.getId()) else {
             throw PluginError.calendarNotFound
+        }
+        guard calendar.allowsContentModifications else {
+            throw PluginError.calendarNotModifiable
         }
         if let title = input.getTitle() {
             calendar.title = title

--- a/ios/Plugin/Models/Inputs/CreateCalendarInput.swift
+++ b/ios/Plugin/Models/Inputs/CreateCalendarInput.swift
@@ -2,7 +2,7 @@ import Capacitor
 
 struct CreateCalendarInput {
     private let title: String
-    private var color: CGColor?
+    private var color: CGColor
     private var sourceId: String?
 
     init(call: CAPPluginCall) throws {
@@ -10,9 +10,8 @@ struct CreateCalendarInput {
             throw PluginError.titleMissing
         }
         self.title = title
-        if let color = call.getString("color") {
-            self.color = try UIColor.fromHex(color).cgColor
-        }
+        let colorHex = call.getString("color") ?? "#007AFF"
+        self.color = try UIColor.fromHex(colorHex).cgColor
         if let sourceId = call.getString("sourceId") {
             self.sourceId = sourceId
         }
@@ -22,7 +21,7 @@ struct CreateCalendarInput {
         return title
     }
 
-    func getColor() -> CGColor? {
+    func getColor() -> CGColor {
         return color
     }
 

--- a/ios/Plugin/Models/Inputs/CreateCalendarInput.swift
+++ b/ios/Plugin/Models/Inputs/CreateCalendarInput.swift
@@ -10,7 +10,7 @@ struct CreateCalendarInput {
             throw PluginError.titleMissing
         }
         self.title = title
-        let colorHex = call.getString("color") ?? "#007AFF"
+        let colorHex = call.getString("color") ?? ImplementationHelper.defaultCalendarColorHex
         self.color = try UIColor.fromHex(colorHex).cgColor
         if let sourceId = call.getString("sourceId") {
             self.sourceId = sourceId

--- a/ios/Plugin/Models/Inputs/DeleteCalendarInput.swift
+++ b/ios/Plugin/Models/Inputs/DeleteCalendarInput.swift
@@ -5,7 +5,7 @@ struct DeleteCalendarInput {
 
     init(call: CAPPluginCall) throws {
         guard let id = call.getString("id") else {
-            throw PluginError.idMissing
+            throw PluginError.calendarIdMissing
         }
         self.id = id
     }

--- a/ios/Plugin/Models/Inputs/ModifyCalendarInput.swift
+++ b/ios/Plugin/Models/Inputs/ModifyCalendarInput.swift
@@ -7,7 +7,7 @@ struct ModifyCalendarInput {
 
     init(call: CAPPluginCall) throws {
         guard let id = call.getString("id") else {
-            throw PluginError.idMissing
+            throw PluginError.calendarIdMissing
         }
         self.id = id
         self.title = call.getString("title")
@@ -15,6 +15,9 @@ struct ModifyCalendarInput {
             self.color = try UIColor.fromHex(color).cgColor
         } else {
             self.color = nil
+        }
+        if self.title == nil && self.color == nil {
+            throw PluginError.noFieldsToModify
         }
     }
 

--- a/ios/Plugin/PluginError.swift
+++ b/ios/Plugin/PluginError.swift
@@ -1,64 +1,40 @@
 import Foundation
 
 enum PluginError: LocalizedError {
-    case scopeMissing
-    case invalidScope
-    case unhandledPermissionState
-    case viewControllerMissing
-    case processFailed
-    case idMissing
-    case listIdsMissing
-    case titleMissing
-    case messageMissing
-    case failedToRetrieveEventId
-    case failedToRetrieveCalendarId
-    case eventNotFound
-    case reminderNotFound
-    case invalidUrl
-    case unableToOpenUrl
-    case failedToLaunchReminders
-    case failedToLaunchCalendar
-    case invalidColor
     case calendarIdMissing
     case calendarNotFound
     case calendarNotModifiable
     case calendarSourceNotFound
-    case noFieldsToModify
+    case customError(String)
+    case eventNotFound
+    case failedToLaunchCalendar
+    case failedToLaunchReminders
+    case failedToRetrieveCalendarId
+    case failedToRetrieveEventId
+    case fromDateMissing
+    case idMissing
+    case invalidColor
+    case invalidScope
+    case invalidUrl
+    case listIdsMissing
     case listNotFound
     case listNotModifiable
+    case messageMissing
     case missingFrequency
     case missingInterval
-    case fromDateMissing
+    case noFieldsToModify
+    case processFailed
+    case reminderNotFound
+    case scopeMissing
+    case titleMissing
     case toDateMissing
+    case unableToOpenUrl
     case unimplemented(String)
-    case customError(String)
+    case unhandledPermissionState
+    case viewControllerMissing
 
     var errorDescription: String? {
         switch self {
-        case .scopeMissing:
-            return NSLocalizedString("Scope must be provided.", comment: "Scope missing error")
-        case .invalidScope:
-            return NSLocalizedString("Invalid scope.", comment: "Invalid scope error")
-        case .unhandledPermissionState:
-            return NSLocalizedString("Unhandled permission state.", comment: "Unhandled permission state error")
-        case .viewControllerMissing:
-            return NSLocalizedString("Missing view controller.", comment: "View controller missing error")
-        case .idMissing:
-            return NSLocalizedString("Event ID must be provided.", comment: "Event ID missing error")
-        case .listIdsMissing:
-            return NSLocalizedString("List IDs must be provided.", comment: "List IDs missing error")
-        case .titleMissing:
-            return NSLocalizedString("Title must be provided.", comment: "Title missing error")
-        case .messageMissing:
-            return NSLocalizedString("Message must be provided.", comment: "Message missing error")
-        case .failedToRetrieveEventId:
-            return NSLocalizedString("Failed to retrieve event ID.", comment: "Failed to retrieve event ID error")
-        case .failedToRetrieveCalendarId:
-            return NSLocalizedString("Failed to retrieve calendar ID.", comment: "Failed to retrieve calendar ID error")
-        case .eventNotFound:
-            return NSLocalizedString("Event not found.", comment: "Event not found error")
-        case .reminderNotFound:
-            return NSLocalizedString("Reminder not found.", comment: "Reminder not found error")
         case .calendarIdMissing:
             return NSLocalizedString("Calendar ID must be provided.", comment: "Calendar ID missing error")
         case .calendarNotFound:
@@ -67,36 +43,60 @@ enum PluginError: LocalizedError {
             return NSLocalizedString("Calendar is not modifiable.", comment: "Calendar not modifiable error")
         case .calendarSourceNotFound:
             return NSLocalizedString("Calendar source not found.", comment: "Calendar source not found error")
-        case .noFieldsToModify:
-            return NSLocalizedString("At least one of title or color must be provided.", comment: "No fields to modify error")
+        case .customError(let message):
+            return message
+        case .eventNotFound:
+            return NSLocalizedString("Event not found.", comment: "Event not found error")
+        case .failedToLaunchCalendar:
+            return NSLocalizedString("Failed to launch calendar app.", comment: "Failed to launch calendar app error")
+        case .failedToLaunchReminders:
+            return NSLocalizedString("Failed to launch reminders app.", comment: "Failed to launch reminders app error")
+        case .failedToRetrieveCalendarId:
+            return NSLocalizedString("Failed to retrieve calendar ID.", comment: "Failed to retrieve calendar ID error")
+        case .failedToRetrieveEventId:
+            return NSLocalizedString("Failed to retrieve event ID.", comment: "Failed to retrieve event ID error")
+        case .fromDateMissing:
+            return NSLocalizedString("From date must be provided.", comment: "From date missing error")
+        case .idMissing:
+            return NSLocalizedString("Event ID must be provided.", comment: "Event ID missing error")
+        case .invalidColor:
+            return NSLocalizedString("Invalid color format.", comment: "Invalid color format error")
+        case .invalidScope:
+            return NSLocalizedString("Invalid scope.", comment: "Invalid scope error")
+        case .invalidUrl:
+            return NSLocalizedString("Invalid URL.", comment: "Invalid URL error")
+        case .listIdsMissing:
+            return NSLocalizedString("List IDs must be provided.", comment: "List IDs missing error")
         case .listNotFound:
             return NSLocalizedString("List not found.", comment: "List not found error")
         case .listNotModifiable:
             return NSLocalizedString("List is not modifiable.", comment: "List not modifiable error")
-        case .invalidUrl:
-            return NSLocalizedString("Invalid URL.", comment: "Invalid URL error")
-        case .unableToOpenUrl:
-            return NSLocalizedString("Unable to open URL.", comment: "Unable to open URL error")
-        case .failedToLaunchReminders:
-            return NSLocalizedString("Failed to launch reminders app.", comment: "Failed to launch reminders app error")
-        case .failedToLaunchCalendar:
-            return NSLocalizedString("Failed to launch calendar app.", comment: "Failed to launch calendar app error")
-        case .invalidColor:
-            return NSLocalizedString("Invalid color format.", comment: "Invalid color format error")
-        case .processFailed:
-            return NSLocalizedString("Process failed.", comment: "Process failed error")
+        case .messageMissing:
+            return NSLocalizedString("Message must be provided.", comment: "Message missing error")
         case .missingFrequency:
             return NSLocalizedString("Frequency must be provided.", comment: "Frequency missing error")
         case .missingInterval:
             return NSLocalizedString("Interval must be provided.", comment: "Interval missing error")
-        case .fromDateMissing:
-            return NSLocalizedString("From date must be provided.", comment: "From date missing error")
+        case .noFieldsToModify:
+            return NSLocalizedString("At least one of title or color must be provided.", comment: "No fields to modify error")
+        case .processFailed:
+            return NSLocalizedString("Process failed.", comment: "Process failed error")
+        case .reminderNotFound:
+            return NSLocalizedString("Reminder not found.", comment: "Reminder not found error")
+        case .scopeMissing:
+            return NSLocalizedString("Scope must be provided.", comment: "Scope missing error")
+        case .titleMissing:
+            return NSLocalizedString("Title must be provided.", comment: "Title missing error")
         case .toDateMissing:
             return NSLocalizedString("To date must be provided.", comment: "To date missing error")
+        case .unableToOpenUrl:
+            return NSLocalizedString("Unable to open URL.", comment: "Unable to open URL error")
         case .unimplemented(let methodName):
             return NSLocalizedString("\(methodName) is not implemented on iOS.", comment: "\(methodName) is not implemented on iOS")
-        case .customError(let message):
-            return message
+        case .unhandledPermissionState:
+            return NSLocalizedString("Unhandled permission state.", comment: "Unhandled permission state error")
+        case .viewControllerMissing:
+            return NSLocalizedString("Missing view controller.", comment: "View controller missing error")
         }
     }
 }

--- a/ios/Plugin/PluginError.swift
+++ b/ios/Plugin/PluginError.swift
@@ -19,7 +19,11 @@ enum PluginError: LocalizedError {
     case failedToLaunchReminders
     case failedToLaunchCalendar
     case invalidColor
+    case calendarIdMissing
     case calendarNotFound
+    case calendarNotModifiable
+    case calendarSourceNotFound
+    case noFieldsToModify
     case listNotFound
     case listNotModifiable
     case missingFrequency
@@ -55,8 +59,16 @@ enum PluginError: LocalizedError {
             return NSLocalizedString("Event not found.", comment: "Event not found error")
         case .reminderNotFound:
             return NSLocalizedString("Reminder not found.", comment: "Reminder not found error")
+        case .calendarIdMissing:
+            return NSLocalizedString("Calendar ID must be provided.", comment: "Calendar ID missing error")
         case .calendarNotFound:
             return NSLocalizedString("Calendar not found.", comment: "Calendar not found error")
+        case .calendarNotModifiable:
+            return NSLocalizedString("Calendar is not modifiable.", comment: "Calendar not modifiable error")
+        case .calendarSourceNotFound:
+            return NSLocalizedString("Calendar source not found.", comment: "Calendar source not found error")
+        case .noFieldsToModify:
+            return NSLocalizedString("At least one of title or color must be provided.", comment: "No fields to modify error")
         case .listNotFound:
             return NSLocalizedString("List not found.", comment: "List not found error")
         case .listNotModifiable:

--- a/ios/Plugin/Utils/ImplementationHelper.swift
+++ b/ios/Plugin/Utils/ImplementationHelper.swift
@@ -2,6 +2,9 @@ import EventKit
 import Capacitor
 
 struct ImplementationHelper {
+    /// Default calendar color when `color` is omitted: `#007AFF` (light-mode iOS system blue).
+    static let defaultCalendarColorHex = "#007AFF"
+
     static func permissionStateToResult(state: EKAuthorizationStatus, scope: CalendarPermissionScope ) throws -> CAPPermissionState {
         var result: CAPPermissionState
 

--- a/src/schemas/interfaces/create-calendar-options.ts
+++ b/src/schemas/interfaces/create-calendar-options.ts
@@ -8,29 +8,40 @@ export interface CreateCalendarOptions {
    */
   title: string;
   /**
-   * The color of the calendar.
-   * Should be provided on Android.
+   * The color of the calendar as `#RRGGBB` or `#RRGGBBAA`.
+   *
+   * When omitted, Android and iOS use `#007AFF` (light-mode iOS system blue).
    *
    * @platform Android, iOS
-   * @example #0000FF
+   * @example #007AFF
+   * @default #007AFF
    * @since 5.2.0
    */
   color?: string;
   /**
+   * The EventKit source (account) where the calendar should be created.
+   *
+   * If provided, it must match an existing source from `fetchAllCalendarSources()`.
+   * If omitted, iCloud is used when available, otherwise the local source.
+   *
    * @platform iOS
    * @since 5.2.0
    */
   sourceId?: string;
   /**
-   * Only needed on Android. Typically set to an email address.
+   * The account under which the calendar is registered.
+   * Required on Android. Typically an email address.
    *
+   * @example plugin@example.com
    * @platform Android
    * @since 7.1.0
    */
   accountName?: string;
   /**
-   * Only needed on Android. Typically set to an email address.
+   * The owner of the calendar.
+   * Required on Android. Typically an email address.
    *
+   * @example plugin@example.com
    * @platform Android
    * @since 7.1.0
    */

--- a/src/schemas/interfaces/delete-calendar-options.ts
+++ b/src/schemas/interfaces/delete-calendar-options.ts
@@ -3,6 +3,7 @@
  */
 export interface DeleteCalendarOptions {
   /**
+   * @platform Android, iOS
    * @since 7.1.0
    */
   id: string;

--- a/src/schemas/interfaces/modify-calendar-options.ts
+++ b/src/schemas/interfaces/modify-calendar-options.ts
@@ -13,17 +13,12 @@ export interface ModifyCalendarOptions {
    * On Android this updates both `CALENDAR_DISPLAY_NAME` (`title`) and
    * `Calendars.NAME` (`internalTitle`).
    *
-   * At least one of `title` or `color` must be provided.
-   *
    * @platform Android, iOS
    * @since 7.2.0
    */
   title?: string;
   /**
    * The color of the calendar as `#RRGGBB` or `#RRGGBBAA`.
-   *
-   * Omit to leave the color unchanged. At least one of `title` or `color`
-   * must be provided.
    *
    * @platform Android, iOS
    * @example #007AFF

--- a/src/schemas/interfaces/modify-calendar-options.ts
+++ b/src/schemas/interfaces/modify-calendar-options.ts
@@ -8,13 +8,25 @@ export interface ModifyCalendarOptions {
    */
   id: string;
   /**
+   * Display title of the calendar.
+   *
+   * On Android this updates both `CALENDAR_DISPLAY_NAME` (`title`) and
+   * `Calendars.NAME` (`internalTitle`).
+   *
+   * At least one of `title` or `color` must be provided.
+   *
    * @platform Android, iOS
    * @since 7.2.0
    */
   title?: string;
   /**
+   * The color of the calendar as `#RRGGBB` or `#RRGGBBAA`.
+   *
+   * Omit to leave the color unchanged. At least one of `title` or `color`
+   * must be provided.
+   *
    * @platform Android, iOS
-   * @example #0000FF
+   * @example #007AFF
    * @since 7.2.0
    */
   color?: string;

--- a/src/sub-definitions/calendar-operations.ts
+++ b/src/sub-definitions/calendar-operations.ts
@@ -82,6 +82,23 @@ export interface CalendarOperations {
   /**
    * Creates a calendar.
    *
+   * `title` is required. `color` is optional and defaults to `#007AFF`.
+   * On Android, `accountName` and `ownerAccount` are required at runtime.
+   *
+   * @example
+   * CapacitorCalendar.createCalendar({
+   *   title: 'Work',
+   *   accountName: 'plugin@example.com',
+   *   ownerAccount: 'plugin@example.com',
+   * });
+   *
+   * @throws {Error} `Title must be provided.` — when `title` is missing.
+   * @throws {Error} `Invalid color format.` — when `color` is present but invalid.
+   * @throws {Error} `Account name must be provided.` — when `accountName` is missing on Android.
+   * @throws {Error} `Owner account must be provided.` — when `ownerAccount` is missing on Android.
+   * @throws {Error} `Calendar source not found.` — when `sourceId` is set and no EventKit source matches (iOS).
+   * @throws {Error} `Failed to retrieve calendar ID.` — when the calendar is created but no id is returned.
+   *
    * @platform Android, iOS
    * @since 5.2.0
    */
@@ -89,12 +106,25 @@ export interface CalendarOperations {
   /**
    * Deletes a calendar by id.
    *
+   * @throws {Error} `Calendar ID must be provided.` — when `id` is missing.
+   * @throws {Error} `Invalid calendar ID.` — when `id` is not a numeric Android calendar id.
+   * @throws {Error} `Calendar not found.` — when no calendar exists for `id`.
+   *
    * @platform Android, iOS
    * @since 5.2.0
    */
   deleteCalendar(options: DeleteCalendarOptions): Promise<void>;
   /**
    * Modifies a calendar with options.
+   *
+   * At least one of `title` or `color` must be provided.
+   *
+   * @throws {Error} `Calendar ID must be provided.` — when `id` is missing.
+   * @throws {Error} `Invalid calendar ID.` — when `id` is not a numeric Android calendar id.
+   * @throws {Error} `At least one of title or color must be provided.` — when both are omitted.
+   * @throws {Error} `Invalid color format.` — when `color` is present but invalid.
+   * @throws {Error} `Calendar not found.` — when no calendar exists for `id`.
+   * @throws {Error} `Calendar is not modifiable.` — when the calendar cannot be modified (iOS).
    *
    * @platform Android, iOS
    * @since 7.2.0

--- a/src/sub-definitions/calendar-operations.ts
+++ b/src/sub-definitions/calendar-operations.ts
@@ -117,8 +117,6 @@ export interface CalendarOperations {
   /**
    * Modifies a calendar with options.
    *
-   * At least one of `title` or `color` must be provided.
-   *
    * @throws {Error} `Calendar ID must be provided.` — when `id` is missing.
    * @throws {Error} `Invalid calendar ID.` — when `id` is not a numeric Android calendar id.
    * @throws {Error} `At least one of title or color must be provided.` — when both are omitted.


### PR DESCRIPTION
## Summary
- Make `createCalendar` `color` optional on Android and iOS with a shared `#007AFF` default.
- iOS `sourceId`: reject if unknown; if omitted, use iCloud then local (same as `createRemindersList`).
- Align create/modify/delete errors (calendar id, not-found, invalid color, no fields to modify).
- Reject id-only `modifyCalendar`; on iOS reject non-modifiable calendars; on Android update both `NAME` and `CALENDAR_DISPLAY_NAME` when `title` is set.

Stacked on #259. Review after that PR. GitHub will retarget this PR to `main` when #259 merges.

Closes: #247
Closes: #248

## Test plan
- [ ] Android `createCalendar({ title, accountName, ownerAccount })` succeeds and uses `#007AFF`.
- [ ] iOS `createCalendar` with a bad `sourceId` rejects `Calendar source not found.`
- [ ] iOS omitted `sourceId` creates on iCloud if available, otherwise local.
- [ ] `modifyCalendar({ id })` rejects on Android and iOS.
- [ ] Missing calendar id says `Calendar ID must be provided.` (not Event ID).
- [ ] After Android `modifyCalendar` with `title`, `listCalendars` `title` and `internalTitle` match.