### PR TITLE
feat(web): support createEvent with ICS file export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Contents
 
 - [Version 8.x.x](#version-8xx)
+  - [8.5.0](#850)
   - [8.4.0](#840)
   - [8.3.0](#830)
   - [8.2.0](#820)
@@ -43,6 +44,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 # Version 8.x.x
 
 Changelogs for the versions supporting Capacitor 8.
+
+## 8.5.0
+
+### Added
+
+- Web support for `createEvent(...)` — returns an `.ics` `File` as `CreateEventResult.ics` (`id` is always `null` on web)
+- `downloadIcsFile(...)` helper to trigger a browser download of an `.ics` `File`
 
 ## 8.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ Changelogs for the versions supporting Capacitor 8.
 ### Added
 
 - Web support for `createEvent(...)` — returns an `.ics` `File` as `CreateEventResult.ics` (`id` is always `null` on web)
+- `CreateEventResult` for `createEvent(...)`
+- `CreateEventWithPromptResult` for `createEventWithPrompt(...)`
+- `CreateEventOptions.icsFileName` for web `.ics` downloads
 - `downloadIcsFile(...)` helper to trigger a browser download of an `.ics` `File`
 
 ## 8.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,11 +49,15 @@ Changelogs for the versions supporting Capacitor 8.
 
 ### Added
 
-- Web support for `createEvent(...)` — returns an `.ics` `File` as `CreateEventResult.ics` (`id` is always `null` on web)
+- Web support for `createEvent(...)` — returns an `.ics` `File` as `CreateEventResult.ics` (`id` is always `null` on web; no system calendar write or auto-download)
 - `CreateEventResult` for `createEvent(...)`
 - `CreateEventWithPromptResult` for `createEventWithPrompt(...)`
 - `CreateEventOptions.icsFileName` for web `.ics` downloads
 - `downloadIcsFile(...)` helper to trigger a browser download of an `.ics` `File`
+
+### Changed
+
+- `CreateEventResult.id` is now `string | null` (was `string`). Native still returns a string; web always returns `null`. Narrow the type when assuming a system event id.
 
 ## 8.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ Changelogs for the versions supporting Capacitor 8.
 - `CreateEventResult` for `createEvent(...)`
 - `CreateEventWithPromptResult` for `createEventWithPrompt(...)`
 - `CreateEventOptions.icsFileName` for web `.ics` downloads
-- `downloadIcsFile(...)` helper to trigger a browser download of an `.ics` `File`
+- `downloadIcsFile(...)` helper to download an `.ics` `File` in the browser
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -488,7 +488,10 @@ createEvent(options: CreateEventOptions) => Promise<CreateEventResult>
 ```
 
 Creates an event in the calendar.
-On Web, builds an `.ics` `File` and returns it as `ics` with `id` always `null`.
+On Android and iOS, inserts into the system calendar and returns its `id`.
+On Web, there is no system calendar store: builds an `.ics` `File` as `ics`.
+The app must download or open that file (for example with `downloadIcsFile(...)`);
+this method does not trigger a download.
 
 | Param         | Type                                                              |
 | ------------- | ----------------------------------------------------------------- |
@@ -1118,10 +1121,10 @@ Options for {@link CalendarAccess#requestPermission}.
 
 #### CreateEventResult
 
-| Prop      | Type                        | Description                                                                                                      | Since | Platform     |
-| --------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------- | ----- | ------------ |
-| **`ics`** | <code>File</code>           | An `.ics` file (`text/calendar`) with one `VEVENT`. Use `downloadIcsFile(...)` to download it in the browser.    | 8.5.0 | Web          |
-| **`id`**  | <code>string \| null</code> | The identifier of the created event. Always `null` on Web. Present on Android and iOS after a successful create. | 0.4.0 | Android, iOS |
+| Prop      | Type                        | Description                                                                                                                                                                                               | Since | Platform     |
+| --------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ------------ |
+| **`ics`** | <code>File</code>           | An `.ics` file (`text/calendar`) with one `VEVENT`. Present only on Web. The plugin does not write to a calendar store or start a download; use `downloadIcsFile(...)` or pass the `File` to another API. | 8.5.0 | Web          |
+| **`id`**  | <code>string \| null</code> | The identifier of the created event. Always `null` on Web. Present on Android and iOS after a successful create.                                                                                          | 0.4.0 | Android, iOS |
 
 #### CreateEventOptions
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Full-featured Capacitor plugin for native calendar and reminders access. Manage 
 
 - **iOS** — Full support (including Reminders and advanced features)
 - **Android** — Strong support for all core calendar features
-- **Web** — Not supported (Capacitor stub only - calls will fail)
+- **Web** — Partial support (creating events; other methods are unimplemented stubs)
 
 ## Why this plugin?
 
@@ -441,18 +441,18 @@ A grant covers both `readReminders` and `writeReminders`.
 ### createEventWithPrompt(...)
 
 ```typescript
-createEventWithPrompt(options?: CreateEventWithPromptOptions | undefined) => Promise<{ id: string | null; }>
+createEventWithPrompt(options?: CreateEventWithPromptOptions | undefined) => Promise<CreateEventWithPromptResult>
 ```
 
 Opens the system calendar interface to create a new event.
-On Android always returns `null`.
+On Android always returns `null` for `id`.
 Fetch the events to find the ID of the newly created event.
 
 | Param         | Type                                                                                  |
 | ------------- | ------------------------------------------------------------------------------------- |
 | **`options`** | <code><a href="#createeventwithpromptoptions">CreateEventWithPromptOptions</a></code> |
 
-**Returns:** <code>Promise&lt;{ id: string | null; }&gt;</code>
+**Returns:** <code>Promise&lt;<a href="#createeventwithpromptresult">CreateEventWithPromptResult</a>&gt;</code>
 
 **Since:** 0.1.0
 
@@ -484,20 +484,21 @@ On Android always returns `null`.
 ### createEvent(...)
 
 ```typescript
-createEvent(options: CreateEventOptions) => Promise<{ id: string; }>
+createEvent(options: CreateEventOptions) => Promise<CreateEventResult>
 ```
 
 Creates an event in the calendar.
+On Web, builds an `.ics` `File` and returns it as `ics` with `id` always `null`.
 
 | Param         | Type                                                              |
 | ------------- | ----------------------------------------------------------------- |
 | **`options`** | <code><a href="#createeventoptions">CreateEventOptions</a></code> |
 
-**Returns:** <code>Promise&lt;{ id: string; }&gt;</code>
+**Returns:** <code>Promise&lt;<a href="#createeventresult">CreateEventResult</a>&gt;</code>
 
 **Since:** 0.4.0
 
-**Platform:** iOS, Android
+**Platform:** Android, iOS, Web
 
 ---
 
@@ -1060,6 +1061,12 @@ Options for {@link CalendarAccess#requestPermission}.
 | ----------- | --------------------------------------------------------------------------- | -------------------------------- | ----- | ------------ |
 | **`scope`** | <code><a href="#calendarpermissionscope">CalendarPermissionScope</a></code> | The permission scope to request. | 8.3.1 | Android, iOS |
 
+#### CreateEventWithPromptResult
+
+| Prop     | Type                        | Description                                                                                        | Since | Platform     |
+| -------- | --------------------------- | -------------------------------------------------------------------------------------------------- | ----- | ------------ |
+| **`id`** | <code>string \| null</code> | The identifier of the created event. Always `null` on Android. Present on iOS when the user saves. | 0.1.0 | Android, iOS |
+
 #### CreateEventWithPromptOptions
 
 | Prop               | Type                                                                | Description                                                                                                                                                                                      | Since | Platform     |
@@ -1109,26 +1116,34 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`url`**          | <code>string</code>                                                 |                                                                                                                                                                                                  | 0.1.0 | iOS          |
 | **`id`**           | <code>string</code>                                                 | The ID of the event to be modified.                                                                                                                                                              | 7.1.0 | Android, iOS |
 
+#### CreateEventResult
+
+| Prop      | Type                        | Description                                                                                                      | Since | Platform     |
+| --------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------- | ----- | ------------ |
+| **`ics`** | <code>File</code>           | An `.ics` file (`text/calendar`) with one `VEVENT`. Use `downloadIcsFile(...)` to download it in the browser.    | 8.5.0 | Web          |
+| **`id`**  | <code>string \| null</code> | The identifier of the created event. Always `null` on Web. Present on Android and iOS after a successful create. | 0.4.0 | Android, iOS |
+
 #### CreateEventOptions
 
-| Prop               | Type                                                                | Description                                                                                                                                            | Default           | Since | Platform     |
-| ------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------- | ----- | ------------ |
-| **`alerts`**       | <code>number[]</code>                                               | Alert times in minutes relative to the event start. Use negative numbers for alerts before the start, and positive numbers for alerts after the start. |                   | 7.1.0 | Android, iOS |
-| **`attendees`**    | <code>EventGuest[]</code>                                           | The event guests.                                                                                                                                      |                   | 7.1.0 | Android      |
-| **`availability`** | <code><a href="#eventavailability">EventAvailability</a></code>     |                                                                                                                                                        |                   | 7.1.0 | Android, iOS |
-| **`calendarId`**   | <code>string</code>                                                 |                                                                                                                                                        |                   | 0.1.0 | Android, iOS |
-| **`color`**        | <code>string</code>                                                 |                                                                                                                                                        |                   | 7.1.0 | Android      |
-| **`commit`**       | <code>boolean</code>                                                | Whether to save immediately (`true`) or batch changes for later (`false`).                                                                             | <code>true</code> | 7.1.0 | iOS          |
-| **`description`**  | <code>string</code>                                                 |                                                                                                                                                        |                   | 7.1.0 | Android, iOS |
-| **`duration`**     | <code>string</code>                                                 | Duration of the event in RFC2445 format.                                                                                                               |                   | 7.1.0 | Android      |
-| **`endDate`**      | <code>number</code>                                                 |                                                                                                                                                        |                   | 0.1.0 | Android, iOS |
-| **`isAllDay`**     | <code>boolean</code>                                                |                                                                                                                                                        |                   | 0.1.0 | Android, iOS |
-| **`location`**     | <code>string</code>                                                 |                                                                                                                                                        |                   | 0.1.0 | Android, iOS |
-| **`organizer`**    | <code>string</code>                                                 | Email of the event organizer.                                                                                                                          |                   | 7.1.0 | Android      |
-| **`recurrence`**   | <code><a href="#eventrecurrencerule">EventRecurrenceRule</a></code> | Rules for creating a recurring event.                                                                                                                  |                   | 7.3.0 | Android, iOS |
-| **`startDate`**    | <code>number</code>                                                 |                                                                                                                                                        |                   | 0.1.0 | Android, iOS |
-| **`title`**        | <code>string</code>                                                 |                                                                                                                                                        |                   | 0.4.0 | Android, iOS |
-| **`url`**          | <code>string</code>                                                 |                                                                                                                                                        |                   | 0.1.0 | iOS          |
+| Prop               | Type                                                                | Description                                                                                                                                                           | Default           | Since | Platform          |
+| ------------------ | ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | ----- | ----------------- |
+| **`alerts`**       | <code>number[]</code>                                               | Alert times in minutes relative to the event start. Use negative numbers for alerts before the start, and positive numbers for alerts after the start.                |                   | 7.1.0 | Android, iOS, Web |
+| **`attendees`**    | <code>EventGuest[]</code>                                           | The event guests.                                                                                                                                                     |                   | 7.1.0 | Android, Web      |
+| **`availability`** | <code><a href="#eventavailability">EventAvailability</a></code>     |                                                                                                                                                                       |                   | 7.1.0 | Android, iOS, Web |
+| **`calendarId`**   | <code>string</code>                                                 |                                                                                                                                                                       |                   | 0.1.0 | Android, iOS      |
+| **`color`**        | <code>string</code>                                                 |                                                                                                                                                                       |                   | 7.1.0 | Android           |
+| **`commit`**       | <code>boolean</code>                                                | Whether to save immediately (`true`) or batch changes for later (`false`).                                                                                            | <code>true</code> | 7.1.0 | iOS               |
+| **`description`**  | <code>string</code>                                                 |                                                                                                                                                                       |                   | 7.1.0 | Android, iOS, Web |
+| **`duration`**     | <code>string</code>                                                 | Duration of the event in RFC2445 format.                                                                                                                              |                   | 7.1.0 | Android           |
+| **`endDate`**      | <code>number</code>                                                 |                                                                                                                                                                       |                   | 0.1.0 | Android, iOS, Web |
+| **`icsFileName`**  | <code>string</code>                                                 | Download filename for the `.ics` file. When omitted, a name is derived from `title` (fallback `event.ics`). If the value has no `.ics` extension, `.ics` is appended. |                   | 8.5.0 | Web               |
+| **`isAllDay`**     | <code>boolean</code>                                                |                                                                                                                                                                       |                   | 0.1.0 | Android, iOS, Web |
+| **`location`**     | <code>string</code>                                                 |                                                                                                                                                                       |                   | 0.1.0 | Android, iOS, Web |
+| **`organizer`**    | <code>string</code>                                                 | Email of the event organizer.                                                                                                                                         |                   | 7.1.0 | Android, Web      |
+| **`recurrence`**   | <code><a href="#eventrecurrencerule">EventRecurrenceRule</a></code> | Rules for creating a recurring event.                                                                                                                                 |                   | 7.3.0 | Android, iOS, Web |
+| **`startDate`**    | <code>number</code>                                                 |                                                                                                                                                                       |                   | 0.1.0 | Android, iOS, Web |
+| **`title`**        | <code>string</code>                                                 |                                                                                                                                                                       |                   | 0.4.0 | Android, iOS, Web |
+| **`url`**          | <code>string</code>                                                 |                                                                                                                                                                       |                   | 0.1.0 | iOS, Web          |
 
 #### EventGuest
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Full-featured Capacitor plugin for native calendar and reminders access. Manage 
 
 - **iOS** — Full support (including Reminders and advanced features)
 - **Android** — Strong support for all core calendar features
-- **Web** — Partial support (creating events; other methods are unimplemented stubs)
+- **Web** — Partial support (create event)
 
 ## Why this plugin?
 
@@ -51,7 +51,7 @@ Full-featured Capacitor plugin for native calendar and reminders access. Manage 
 `@ebarooni/capacitor-calendar` ships an official [MCP](https://modelcontextprotocol.io) server so AI coding assistants can work with the plugin accurately.
 
 ```bash
-docker run --rm -d --name capacitor-calendar-mcp -p 8080:8080 ghcr.io/ebarooni/capacitor-calendar-mcp:1.0.0
+docker run --rm -d --name capacitor-calendar-mcp -p 8080:8080 ghcr.io/ebarooni/capacitor-calendar-mcp:1.1.0
 ```
 
 See [`mcp/README.md`](mcp/README.md) for client configuration and full details.

--- a/example-app/package-lock.json
+++ b/example-app/package-lock.json
@@ -20,7 +20,7 @@
     },
     "..": {
       "name": "@ebarooni/capacitor-calendar",
-      "version": "8.4.0",
+      "version": "8.5.0",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^8.0.0",

--- a/example-app/src/js/example.js
+++ b/example-app/src/js/example.js
@@ -1,4 +1,5 @@
-import { CapacitorCalendar, EventAvailability, EventSpan } from '@ebarooni/capacitor-calendar';
+import { Capacitor } from '@capacitor/core';
+import { CapacitorCalendar, downloadIcsFile, EventAvailability, EventSpan } from '@ebarooni/capacitor-calendar';
 
 document.addEventListener('DOMContentLoaded', () => {
   const calendarColorSelect = document.querySelector('#calendar-color-select');
@@ -25,19 +26,18 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   document.querySelector('#create-event').addEventListener('click', async () => {
-    const { result: calendars } = await CapacitorCalendar.listCalendars();
     const startDate = Date.now();
     const endDate = startDate + 60 * 60 * 1000;
     const recurrenceEnd = startDate + 14 * 24 * 60 * 60 * 1000;
-    const result = await CapacitorCalendar.createEvent({
+    const options = {
       alerts: [-1440, -60, 30],
       attendees: [{ email: 'guest@example.com', name: 'Alex Guest' }],
       availability: EventAvailability.BUSY,
-      calendarId: pickNonHolidayCalendar(calendars)?.id,
       ...optionalCalendarColor(),
       commit: true,
       description: 'Created with @ebarooni/capacitor-calendar',
       endDate,
+      icsFileName: 'recurring-standup.ics',
       isAllDay: false,
       location: 'Conference Room A',
       organizer: 'organizer@example.com',
@@ -49,9 +49,23 @@ document.addEventListener('DOMContentLoaded', () => {
       startDate,
       title: 'Recurring standup',
       url: 'https://example.com/standup',
-    });
+    };
 
-    getEventIdInput().value = result.id;
+    // listCalendars is not implemented on web; calendarId is ignored there anyway
+    if (Capacitor.getPlatform() !== 'web') {
+      const { result: calendars } = await CapacitorCalendar.listCalendars();
+      options.calendarId = pickNonHolidayCalendar(calendars)?.id;
+    }
+
+    const result = await CapacitorCalendar.createEvent(options);
+
+    if (result.id) {
+      getEventIdInput().value = result.id;
+    }
+    if (result.ics) {
+      downloadIcsFile(result.ics);
+      console.log('#createEvent ics', result.ics.name, result.ics.type, result.ics.size);
+    }
     console.log('#createEvent', result);
   });
 

--- a/example-app/src/js/example.js
+++ b/example-app/src/js/example.js
@@ -63,8 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
       getEventIdInput().value = result.id;
     }
     if (result.ics) {
-      downloadIcsFile(result.ics);
-      console.log('#createEvent ics', result.ics.name, result.ics.type, result.ics.size);
+      await downloadIcsFile(result.ics);
     }
     console.log('#createEvent', result);
   });

--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -8,9 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Contents
 
 - [Version 1.x.x](#version-1xx)
+  - [1.1.0](#110)
   - [1.0.0](#100)
 
 # Version 1.x.x
+
+## 1.1.0
+
+### Changed
+
+- `createEvent` now lists Web support (ICS file export)
+- `listMethods` and `searchMethods` platform filter docs include `web`
 
 ## 1.0.0
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -6,7 +6,7 @@
     <img src="https://img.shields.io/npm/l/@ebarooni/capacitor-calendar?style=flat-square" />
   </a>
   <a href="https://www.npmjs.com/package/@ebarooni/capacitor-calendar">
-    <img src="https://img.shields.io/npm/dw/@ebarooni/capacitor-calendar?style=flat-square" />
+    <img src="https://img.shields.io/npm/dm/@ebarooni/capacitor-calendar?style=flat-square" />
   </a>
   <a href="https://www.npmjs.com/package/@ebarooni/capacitor-calendar">
     <img src="https://img.shields.io/npm/v/@ebarooni/capacitor-calendar?style=flat-square" />
@@ -25,7 +25,7 @@ Built with [Quarkus](https://quarkus.io). Published to the GitHub Container Regi
 ## Getting Started
 
 ```bash
-docker run --rm -d --name capacitor-calendar-mcp -p 8080:8080 ghcr.io/ebarooni/capacitor-calendar-mcp:1.0.0
+docker run --rm -d --name capacitor-calendar-mcp -p 8080:8080 ghcr.io/ebarooni/capacitor-calendar-mcp:1.1.0
 ```
 
 The server starts at `http://localhost:8080/mcp`.
@@ -33,7 +33,7 @@ The server starts at `http://localhost:8080/mcp`.
 If port 8080 is already in use, map it to any available port on your machine:
 
 ```bash
-docker run --rm -d --name capacitor-calendar-mcp -p 9090:8080 ghcr.io/ebarooni/capacitor-calendar-mcp:1.0.0
+docker run --rm -d --name capacitor-calendar-mcp -p 9090:8080 ghcr.io/ebarooni/capacitor-calendar-mcp:1.1.0
 ```
 
 The server would then be available at `http://localhost:9090/mcp`. Update your client configuration accordingly.
@@ -122,7 +122,7 @@ Open `mcp.json` in your editor and add the following:
 All available versions are listed on the [GitHub Packages page](https://github.com/ebarooni/capacitor-calendar/pkgs/container/capacitor-calendar-mcp). Always use a specific version tag:
 
 ```bash
-docker run --rm -d --name capacitor-calendar-mcp -p 8080:8080 ghcr.io/ebarooni/capacitor-calendar-mcp:1.0.0
+docker run --rm -d --name capacitor-calendar-mcp -p 8080:8080 ghcr.io/ebarooni/capacitor-calendar-mcp:1.1.0
 ```
 
 ## Local Development

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>dev.barooni</groupId>
     <artifactId>capacitor-calendar-mcp</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>quarkus</packaging>
 
     <properties>

--- a/mcp/src/main/java/dev/barooni/capacitorcalendar/mcp/tools/MethodTools.java
+++ b/mcp/src/main/java/dev/barooni/capacitorcalendar/mcp/tools/MethodTools.java
@@ -105,8 +105,9 @@ public class MethodTools {
         // --- Event Operations ---
         new PluginMethod(
             "createEvent",
-            "Creates an event in the calendar.",
-            List.of("Android", "iOS"), "0.4.0", false
+            "Creates an event in the calendar. On Web, returns an .ics File as ics with id always null; " +
+                "optional icsFileName sets the download name. Use the exported downloadIcsFile helper to download it.",
+            List.of("Android", "iOS", "Web"), "0.4.0", false
         ),
         new PluginMethod(
             "createEventWithPrompt",
@@ -234,11 +235,11 @@ public class MethodTools {
 
     @Tool(
         description = "Lists all available @ebarooni/capacitor-calendar method names. " +
-                    "Optionally filter by platform (ios or android). " +
+                    "Optionally filter by platform (ios, android, or web). " +
                     "Use this to discover available methods before calling getMethod or searchMethods."
     )
     public String listMethods(
-        @ToolArg(description = "Optional platform filter: ios or android. Leave empty to list all platforms.")
+        @ToolArg(description = "Optional platform filter: ios, android, or web. Leave empty to list all platforms.")
         String platform
     ) {
         String pl = platform == null ? "" : platform.toLowerCase();
@@ -259,13 +260,13 @@ public class MethodTools {
 
     @Tool(
         description = "Searches @ebarooni/capacitor-calendar methods by keyword. Matches against method " +
-                      "names and descriptions. Optionally filter by platform (ios or android). " +
+                      "names and descriptions. Optionally filter by platform (ios, android, or web). " +
                       "Returns all matching methods with their description, platforms, and since version."
     )
     public String searchMethods(
         @ToolArg(description = "Keyword to search for in method names and descriptions")
         String keyword,
-        @ToolArg(description = "Optional platform filter: ios or android. Leave empty to search all platforms.")
+        @ToolArg(description = "Optional platform filter: ios, android, or web. Leave empty to search all platforms.")
         String platform
     ) {
         String kw = keyword.toLowerCase();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebarooni/capacitor-calendar",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebarooni/capacitor-calendar",
-      "version": "8.4.0",
+      "version": "8.5.0",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebarooni/capacitor-calendar",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "description": "A capacitor plugin for managing calendar events on iOS and Android, with reminders support on iOS.",
   "author": "Ehsan Barooni",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,9 @@ import type { CheckPermissionOptions } from './schemas/interfaces/check-permissi
 import type { CreateCalendarOptions } from './schemas/interfaces/create-calendar-options';
 import type { CreateCalendarResult } from './schemas/interfaces/create-calendar-result';
 import type { CreateEventOptions } from './schemas/interfaces/create-event-options';
+import type { CreateEventResult } from './schemas/interfaces/create-event-result';
 import type { CreateEventWithPromptOptions } from './schemas/interfaces/create-event-with-prompt-options';
+import type { CreateEventWithPromptResult } from './schemas/interfaces/create-event-with-prompt-result';
 import type { CreateReminderOptions } from './schemas/interfaces/create-reminder-options';
 import type { CreateRemindersListOptions } from './schemas/interfaces/create-reminders-list-options';
 import type { CreateRemindersListResult } from './schemas/interfaces/create-reminders-list-result';
@@ -57,6 +59,7 @@ import type { RecurrenceFrequency } from './schemas/types/recurrence-frequency';
 import type { CheckAllPermissionsResult, RequestAllPermissionsResult } from './sub-definitions/calendar-access';
 import type { DeleteEventsByIdResult } from './sub-definitions/event-operations';
 import type { DeleteRemindersByIdResult } from './sub-definitions/reminders-operations';
+import { downloadIcsFile } from './web/download-ics-file';
 
 const CapacitorCalendar = registerPlugin<CapacitorCalendarPlugin>('CapacitorCalendar', {
   web: () => import('./web').then((m) => new m.CapacitorCalendarWeb()),
@@ -72,7 +75,9 @@ export type {
   CreateCalendarOptions,
   CreateCalendarResult,
   CreateEventOptions,
+  CreateEventResult,
   CreateEventWithPromptOptions,
+  CreateEventWithPromptResult,
   CreateReminderOptions,
   CreateRemindersListOptions,
   CreateRemindersListResult,
@@ -124,4 +129,5 @@ export {
   AttendeeType,
   AttendeeStatus,
   CapacitorCalendar,
+  downloadIcsFile,
 };

--- a/src/schemas/interfaces/create-event-options.ts
+++ b/src/schemas/interfaces/create-event-options.ts
@@ -17,19 +17,19 @@ export interface CreateEventOptions {
    * // 30 -> 30 minutes after
    * [-1440, -60, 30]
    *
-   * @platform Android, iOS
+   * @platform Android, iOS, Web
    * @since 7.1.0
    */
   alerts?: number[];
   /**
    * The event guests.
    *
-   * @platform Android
+   * @platform Android, Web
    * @since 7.1.0
    */
   attendees?: EventGuest[];
   /**
-   * @platform Android, iOS
+   * @platform Android, iOS, Web
    * @since 7.1.0
    */
   availability?: EventAvailability;
@@ -54,7 +54,7 @@ export interface CreateEventOptions {
    */
   commit?: boolean;
   /**
-   * @platform Android, iOS
+   * @platform Android, iOS, Web
    * @since 7.1.0
    */
   description?: string;
@@ -68,47 +68,56 @@ export interface CreateEventOptions {
    */
   duration?: string;
   /**
-   * @platform Android, iOS
+   * @platform Android, iOS, Web
    * @since 0.1.0
    */
   endDate?: number;
   /**
-   * @platform Android, iOS
+   * Download filename for the `.ics` file.
+   * When omitted, a name is derived from `title` (fallback `event.ics`).
+   * If the value has no `.ics` extension, `.ics` is appended.
+   *
+   * @example 'team-standup.ics'
+   * @platform Web
+   * @since 8.5.0
+   */
+  icsFileName?: string;
+  /**
+   * @platform Android, iOS, Web
    * @since 0.1.0
    */
   isAllDay?: boolean;
   /**
-   * @platform Android, iOS
+   * @platform Android, iOS, Web
    * @since 0.1.0
    */
   location?: string;
   /**
    * Email of the event organizer.
    *
-   * @platform Android
+   * @platform Android, Web
    * @since 7.1.0
    */
   organizer?: string;
   /**
    * Rules for creating a recurring event.
    *
-   * @platform Android, iOS
+   * @platform Android, iOS, Web
    * @since 7.3.0
    */
   recurrence?: EventRecurrenceRule;
   /**
-   *
-   * @platform Android, iOS
+   * @platform Android, iOS, Web
    * @since 0.1.0
    */
   startDate?: number;
   /**
-   * @platform Android, iOS
+   * @platform Android, iOS, Web
    * @since 0.4.0
    */
   title: string;
   /**
-   * @platform iOS
+   * @platform iOS, Web
    * @since 0.1.0
    */
   url?: string;

--- a/src/schemas/interfaces/create-event-result.ts
+++ b/src/schemas/interfaces/create-event-result.ts
@@ -1,0 +1,22 @@
+/**
+ * @since 8.5.0
+ */
+export interface CreateEventResult {
+  /**
+   * An `.ics` file (`text/calendar`) with one `VEVENT`.
+   * Use `downloadIcsFile(...)` to download it in the browser.
+   *
+   * @platform Web
+   * @since 8.5.0
+   */
+  ics?: File;
+  /**
+   * The identifier of the created event.
+   * Always `null` on Web.
+   * Present on Android and iOS after a successful create.
+   *
+   * @platform Android, iOS
+   * @since 0.4.0
+   */
+  id: string | null;
+}

--- a/src/schemas/interfaces/create-event-result.ts
+++ b/src/schemas/interfaces/create-event-result.ts
@@ -4,7 +4,8 @@
 export interface CreateEventResult {
   /**
    * An `.ics` file (`text/calendar`) with one `VEVENT`.
-   * Use `downloadIcsFile(...)` to download it in the browser.
+   * Present only on Web. The plugin does not write to a calendar store or start a download;
+   * use `downloadIcsFile(...)` or pass the `File` to another API.
    *
    * @platform Web
    * @since 8.5.0

--- a/src/schemas/interfaces/create-event-with-prompt-result.ts
+++ b/src/schemas/interfaces/create-event-with-prompt-result.ts
@@ -1,0 +1,14 @@
+/**
+ * @since 8.5.0
+ */
+export interface CreateEventWithPromptResult {
+  /**
+   * The identifier of the created event.
+   * Always `null` on Android.
+   * Present on iOS when the user saves.
+   *
+   * @platform Android, iOS
+   * @since 0.1.0
+   */
+  id: string | null;
+}

--- a/src/sub-definitions/event-operations.ts
+++ b/src/sub-definitions/event-operations.ts
@@ -1,6 +1,8 @@
 import type { CalendarEvent } from '../schemas/interfaces/calendar-event';
 import type { CreateEventOptions } from '../schemas/interfaces/create-event-options';
+import type { CreateEventResult } from '../schemas/interfaces/create-event-result';
 import type { CreateEventWithPromptOptions } from '../schemas/interfaces/create-event-with-prompt-options';
+import type { CreateEventWithPromptResult } from '../schemas/interfaces/create-event-with-prompt-result';
 import type { DeleteEventOptions } from '../schemas/interfaces/delete-event-options';
 import type { DeleteEventWithPromptOptions } from '../schemas/interfaces/delete-event-with-prompt-options';
 import type { DeleteEventsByIdOptions } from '../schemas/interfaces/delete-events-by-id-options';
@@ -12,7 +14,7 @@ import type { EventEditAction } from '../schemas/types/event-edit-action';
 export interface EventOperations {
   /**
    * Opens the system calendar interface to create a new event.
-   * On Android always returns `null`.
+   * On Android always returns `null` for `id`.
    * Fetch the events to find the ID of the newly created event.
    *
    * @example
@@ -25,7 +27,7 @@ export interface EventOperations {
    * @platform Android, iOS
    * @since 0.1.0
    */
-  createEventWithPrompt(options?: CreateEventWithPromptOptions): Promise<{ id: string | null }>;
+  createEventWithPrompt(options?: CreateEventWithPromptOptions): Promise<CreateEventWithPromptResult>;
   /**
    * Opens a system calendar interface to modify an event.
    * On Android always returns `null`.
@@ -43,11 +45,22 @@ export interface EventOperations {
   modifyEventWithPrompt(options: ModifyEventWithPromptOptions): Promise<{ result: EventEditAction | null }>;
   /**
    * Creates an event in the calendar.
+   * On Web, builds an `.ics` `File` and returns it as `ics` with `id` always `null`.
    *
-   * @platform iOS, Android
+   * @example
+   * const { id, ics } = await CapacitorCalendar.createEvent({
+   *   title: 'Team standup',
+   *   startDate: Date.now(),
+   *   icsFileName: 'team-standup.ics',
+   * });
+   * if (ics) {
+   *   downloadIcsFile(ics);
+   * }
+   *
+   * @platform Android, iOS, Web
    * @since 0.4.0
    */
-  createEvent(options: CreateEventOptions): Promise<{ id: string }>;
+  createEvent(options: CreateEventOptions): Promise<CreateEventResult>;
   /**
    * Modifies an event.
    *

--- a/src/sub-definitions/event-operations.ts
+++ b/src/sub-definitions/event-operations.ts
@@ -57,7 +57,7 @@ export interface EventOperations {
    *   icsFileName: 'team-standup.ics',
    * });
    * if (ics) {
-   *   downloadIcsFile(ics);
+   *   await downloadIcsFile(ics);
    * }
    *
    * @platform Android, iOS, Web

--- a/src/sub-definitions/event-operations.ts
+++ b/src/sub-definitions/event-operations.ts
@@ -45,7 +45,10 @@ export interface EventOperations {
   modifyEventWithPrompt(options: ModifyEventWithPromptOptions): Promise<{ result: EventEditAction | null }>;
   /**
    * Creates an event in the calendar.
-   * On Web, builds an `.ics` `File` and returns it as `ics` with `id` always `null`.
+   * On Android and iOS, inserts into the system calendar and returns its `id`.
+   * On Web, there is no system calendar store: builds an `.ics` `File` as `ics`.
+   * The app must download or open that file (for example with `downloadIcsFile(...)`);
+   * this method does not trigger a download.
    *
    * @example
    * const { id, ics } = await CapacitorCalendar.createEvent({

--- a/src/web.ts
+++ b/src/web.ts
@@ -9,7 +9,9 @@ import type { CheckPermissionOptions } from './schemas/interfaces/check-permissi
 import type { CreateCalendarOptions } from './schemas/interfaces/create-calendar-options';
 import type { CreateCalendarResult } from './schemas/interfaces/create-calendar-result';
 import type { CreateEventOptions } from './schemas/interfaces/create-event-options';
+import type { CreateEventResult } from './schemas/interfaces/create-event-result';
 import type { CreateEventWithPromptOptions } from './schemas/interfaces/create-event-with-prompt-options';
+import type { CreateEventWithPromptResult } from './schemas/interfaces/create-event-with-prompt-result';
 import type { CreateReminderOptions } from './schemas/interfaces/create-reminder-options';
 import type { CreateRemindersListOptions } from './schemas/interfaces/create-reminders-list-options';
 import type { CreateRemindersListResult } from './schemas/interfaces/create-reminders-list-result';
@@ -43,6 +45,7 @@ import type { EventEditAction } from './schemas/types/event-edit-action';
 import type { CheckAllPermissionsResult, RequestAllPermissionsResult } from './sub-definitions/calendar-access';
 import type { DeleteEventsByIdResult } from './sub-definitions/event-operations';
 import type { DeleteRemindersByIdResult } from './sub-definitions/reminders-operations';
+import { buildEventIcs, resolveIcsFileName } from './web/ics';
 
 export class CapacitorCalendarWeb extends WebPlugin implements CapacitorCalendarPlugin {
   public checkPermission(_options: CheckPermissionOptions): Promise<{ result: PermissionState }> {
@@ -89,7 +92,7 @@ export class CapacitorCalendarWeb extends WebPlugin implements CapacitorCalendar
     return this.throwUnimplemented(this.requestFullRemindersAccess.name);
   }
 
-  public createEventWithPrompt(_options: CreateEventWithPromptOptions): Promise<{ id: string | null }> {
+  public createEventWithPrompt(_options: CreateEventWithPromptOptions): Promise<CreateEventWithPromptResult> {
     return this.throwUnimplemented(this.createEventWithPrompt.name);
   }
 
@@ -97,10 +100,17 @@ export class CapacitorCalendarWeb extends WebPlugin implements CapacitorCalendar
     return this.throwUnimplemented(this.modifyEventWithPrompt.name);
   }
 
-  public createEvent(_options: CreateEventOptions): Promise<{
-    id: string;
-  }> {
-    return this.throwUnimplemented(this.createEvent.name);
+  public createEvent(options: CreateEventOptions): Promise<CreateEventResult> {
+    try {
+      const content = buildEventIcs(options);
+      const ics = new File([content], resolveIcsFileName(options), {
+        type: 'text/calendar;charset=utf-8',
+      });
+      return Promise.resolve({ id: null, ics });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return Promise.reject(new Error(message));
+    }
   }
 
   public commit(): Promise<void> {

--- a/src/web/download-ics-file.ts
+++ b/src/web/download-ics-file.ts
@@ -1,6 +1,8 @@
 /**
- * Triggers a browser download for an `.ics` `File` (typically from web `createEvent`).
- * No-op outside a browser document environment.
+ * Triggers a browser download for an `.ics` `File`.
+ * Resolves after the object URL is revoked.
+ *
+ * @throws If `document` or `URL` is not available.
  *
  * @example
  * const { ics } = await CapacitorCalendar.createEvent({
@@ -8,14 +10,14 @@
  *   icsFileName: 'team-standup.ics',
  * });
  * if (ics) {
- *   downloadIcsFile(ics);
+ *   await downloadIcsFile(ics);
  * }
  *
  * @since 8.5.0
  */
-export function downloadIcsFile(file: File): void {
+export async function downloadIcsFile(file: File): Promise<void> {
   if (typeof document === 'undefined' || typeof URL === 'undefined') {
-    return;
+    throw new Error('downloadIcsFile requires a browser document environment.');
   }
 
   const url = URL.createObjectURL(file);
@@ -26,5 +28,6 @@ export function downloadIcsFile(file: File): void {
   link.click();
   link.remove();
   // Delay revoke so the browser can start the download
-  setTimeout(() => URL.revokeObjectURL(url), 1000);
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  URL.revokeObjectURL(url);
 }

--- a/src/web/download-ics-file.ts
+++ b/src/web/download-ics-file.ts
@@ -1,0 +1,30 @@
+/**
+ * Triggers a browser download for an `.ics` `File` (typically from web `createEvent`).
+ * No-op outside a browser document environment.
+ *
+ * @example
+ * const { ics } = await CapacitorCalendar.createEvent({
+ *   title: 'Team standup',
+ *   icsFileName: 'team-standup.ics',
+ * });
+ * if (ics) {
+ *   downloadIcsFile(ics);
+ * }
+ *
+ * @since 8.5.0
+ */
+export function downloadIcsFile(file: File): void {
+  if (typeof document === 'undefined' || typeof URL === 'undefined') {
+    return;
+  }
+
+  const url = URL.createObjectURL(file);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = file.name.length > 0 ? file.name : 'event.ics';
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  // Delay revoke so the browser can start the download
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}

--- a/src/web/ics.ts
+++ b/src/web/ics.ts
@@ -1,0 +1,262 @@
+import { EventAvailability } from '../schemas/enums/event-availability';
+import type { CreateEventOptions } from '../schemas/interfaces/create-event-options';
+import type { EventRecurrenceRule } from '../schemas/interfaces/event-recurrence-rule';
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const CRLF = '\r\n';
+
+/**
+ * Builds an RFC 5545 `VCALENDAR` document with one `VEVENT` from CreateEventOptions.
+ * When `startDate` is omitted, uses the current time. When `endDate` is omitted, uses
+ * one hour after the start (or the next day for all-day events).
+ */
+export function buildEventIcs(options: CreateEventOptions): string {
+  const startDate = options.startDate ?? Date.now();
+  const isAllDay = options.isAllDay === true;
+  const endDate = resolveEndDate(startDate, options.endDate, isAllDay);
+
+  const lines: string[] = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//ebarooni/capacitor-calendar//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    'BEGIN:VEVENT',
+    `UID:${generateUid()}`,
+    `DTSTAMP:${formatDateTimeUtc(Date.now())}`,
+  ];
+
+  if (isAllDay) {
+    lines.push(`DTSTART;VALUE=DATE:${formatDateOnlyLocal(startDate)}`);
+    lines.push(`DTEND;VALUE=DATE:${formatDateOnlyLocal(endDate)}`);
+  } else {
+    lines.push(`DTSTART:${formatDateTimeUtc(startDate)}`);
+    lines.push(`DTEND:${formatDateTimeUtc(endDate)}`);
+  }
+
+  lines.push(`SUMMARY:${escapeText(options.title)}`);
+
+  if (options.description != null && options.description.length > 0) {
+    lines.push(`DESCRIPTION:${escapeText(options.description)}`);
+  }
+  if (options.location != null && options.location.length > 0) {
+    lines.push(`LOCATION:${escapeText(options.location)}`);
+  }
+  if (options.url != null && options.url.length > 0) {
+    lines.push(`URL:${escapeText(options.url)}`);
+  }
+  if (options.organizer != null && options.organizer.length > 0) {
+    lines.push(`ORGANIZER:mailto:${escapeText(options.organizer)}`);
+  }
+
+  const transp = mapTransparency(options.availability);
+  if (transp != null) {
+    lines.push(`TRANSP:${transp}`);
+  }
+
+  if (options.recurrence != null) {
+    lines.push(`RRULE:${toRRule(options.recurrence)}`);
+  }
+
+  if (options.attendees != null) {
+    for (const guest of options.attendees) {
+      if (guest.email.length === 0) {
+        continue;
+      }
+      const cn = guest.name != null && guest.name.length > 0 ? `;CN=${escapeText(guest.name)}` : '';
+      lines.push(`ATTENDEE${cn}:mailto:${escapeText(guest.email)}`);
+    }
+  }
+
+  if (options.alerts != null) {
+    for (const minutes of options.alerts) {
+      lines.push(...buildAlarm(minutes));
+    }
+  }
+
+  lines.push('END:VEVENT', 'END:VCALENDAR');
+
+  return lines.map(foldLine).join(CRLF) + CRLF;
+}
+
+/**
+ * Resolves the `.ics` download filename.
+ * Uses `icsFileName` when set; otherwise derives a name from `title` (fallback `event.ics`).
+ * Appends `.ics` when the chosen name has no such extension.
+ */
+export function resolveIcsFileName(options: Pick<CreateEventOptions, 'icsFileName' | 'title'>): string {
+  const custom = options.icsFileName?.trim();
+  if (custom != null && custom.length > 0) {
+    return /\.ics$/i.test(custom) ? custom : `${custom}.ics`;
+  }
+  return fileNameFromTitle(options.title);
+}
+
+function fileNameFromTitle(title?: string): string {
+  const base = (title ?? 'event')
+    .trim()
+    .replace(/[^\w\s-]+/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 64);
+  return `${base.length > 0 ? base : 'event'}.ics`;
+}
+
+function resolveEndDate(startDate: number, endDate: number | undefined, isAllDay: boolean): number {
+  if (endDate != null) {
+    return endDate;
+  }
+  return isAllDay ? startDate + DAY_MS : startDate + HOUR_MS;
+}
+
+function mapTransparency(availability: EventAvailability | undefined): 'OPAQUE' | 'TRANSPARENT' | null {
+  if (availability == null) {
+    return null;
+  }
+  if (availability === EventAvailability.FREE) {
+    return 'TRANSPARENT';
+  }
+  if (availability === EventAvailability.BUSY) {
+    return 'OPAQUE';
+  }
+  return 'OPAQUE';
+}
+
+function toRRule(rule: EventRecurrenceRule): string {
+  const parts: string[] = [`FREQ=${rule.frequency.toUpperCase()}`, `INTERVAL=${Math.max(1, rule.interval ?? 1)}`];
+
+  if (rule.count != null) {
+    parts.push(`COUNT=${rule.count}`);
+  } else if (rule.end != null) {
+    parts.push(`UNTIL=${formatDateTimeUtc(rule.end)}`);
+  }
+
+  if (rule.byWeekDay != null && rule.byWeekDay.length > 0) {
+    const mapped = rule.byWeekDay.map(mapWeekday).filter((d): d is string => d != null);
+    if (mapped.length > 0) {
+      parts.push(`BYDAY=${[...new Set(mapped)].join(',')}`);
+    }
+  }
+
+  if (rule.byMonthDay != null && rule.byMonthDay.length > 0) {
+    parts.push(`BYMONTHDAY=${rule.byMonthDay.join(',')}`);
+  }
+  if (rule.byMonth != null && rule.byMonth.length > 0) {
+    parts.push(`BYMONTH=${rule.byMonth.join(',')}`);
+  }
+  if (rule.weeksOfTheYear != null && rule.weeksOfTheYear.length > 0) {
+    parts.push(`BYWEEKNO=${rule.weeksOfTheYear.join(',')}`);
+  }
+  if (rule.daysOfTheYear != null && rule.daysOfTheYear.length > 0) {
+    parts.push(`BYYEARDAY=${rule.daysOfTheYear.join(',')}`);
+  }
+
+  return parts.join(';');
+}
+
+function mapWeekday(day: number): string | null {
+  switch (day) {
+    case 1:
+      return 'MO';
+    case 2:
+      return 'TU';
+    case 3:
+      return 'WE';
+    case 4:
+      return 'TH';
+    case 5:
+      return 'FR';
+    case 6:
+      return 'SA';
+    case 7:
+      return 'SU';
+    default:
+      return null;
+  }
+}
+
+function buildAlarm(minutes: number): string[] {
+  const trigger = minutes < 0 ? `-PT${Math.abs(minutes)}M` : `PT${minutes}M`;
+  return ['BEGIN:VALARM', 'ACTION:DISPLAY', 'DESCRIPTION:Reminder', `TRIGGER:${trigger}`, 'END:VALARM'];
+}
+
+function generateUid(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `${crypto.randomUUID()}@capacitor-calendar`;
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 11)}@capacitor-calendar`;
+}
+
+function formatDateTimeUtc(ms: number): string {
+  const d = new Date(ms);
+  const y = d.getUTCFullYear();
+  const mo = pad(d.getUTCMonth() + 1);
+  const day = pad(d.getUTCDate());
+  const h = pad(d.getUTCHours());
+  const mi = pad(d.getUTCMinutes());
+  const s = pad(d.getUTCSeconds());
+  return `${y}${mo}${day}T${h}${mi}${s}Z`;
+}
+
+function formatDateOnlyLocal(ms: number): string {
+  const d = new Date(ms);
+  return `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}`;
+}
+
+function pad(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+/**
+ * Escapes TEXT values per RFC 5545 §3.3.11.
+ */
+export function escapeText(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\r\n|\n|\r/g, '\\n');
+}
+
+/**
+ * Folds a content line so each physical line is at most 75 octets (RFC 5545 §3.1).
+ */
+export function foldLine(line: string): string {
+  const max = 75;
+  if (byteLength(line) <= max) {
+    return line;
+  }
+
+  const chars = [...line];
+  let result = '';
+  let current = '';
+
+  for (const ch of chars) {
+    const next = current + ch;
+    if (byteLength(next) > max) {
+      result += result.length === 0 ? current : `${CRLF} ${current}`;
+      current = ch;
+      // Continuations are limited to 74 octets of content + leading space = 75
+      while (byteLength(current) > max - 1) {
+        // Extremely rare for a single code point; split by taking first unit as-is
+        result += `${CRLF} ${current}`;
+        current = '';
+        break;
+      }
+    } else {
+      current = next;
+    }
+  }
+
+  if (current.length > 0) {
+    result += result.length === 0 ? current : `${CRLF} ${current}`;
+  }
+
+  return result;
+}
+
+function byteLength(s: string): number {
+  return new TextEncoder().encode(s).length;
+}

--- a/src/web/ics.ts
+++ b/src/web/ics.ts
@@ -56,7 +56,7 @@ export function buildEventIcs(options: CreateEventOptions): string {
   }
 
   if (options.recurrence != null) {
-    lines.push(`RRULE:${toRRule(options.recurrence)}`);
+    lines.push(`RRULE:${toRRule(options.recurrence, isAllDay)}`);
   }
 
   if (options.attendees != null) {
@@ -64,7 +64,7 @@ export function buildEventIcs(options: CreateEventOptions): string {
       if (guest.email.length === 0) {
         continue;
       }
-      const cn = guest.name != null && guest.name.length > 0 ? `;CN=${escapeText(guest.name)}` : '';
+      const cn = guest.name != null && guest.name.length > 0 ? `;CN=${formatParamValue(guest.name)}` : '';
       lines.push(`ATTENDEE${cn}:mailto:${escapeText(guest.email)}`);
     }
   }
@@ -105,10 +105,17 @@ function fileNameFromTitle(title?: string): string {
 }
 
 function resolveEndDate(startDate: number, endDate: number | undefined, isAllDay: boolean): number {
-  if (endDate != null) {
-    return endDate;
+  if (!isAllDay) {
+    return endDate ?? startDate + HOUR_MS;
   }
-  return isAllDay ? startDate + DAY_MS : startDate + HOUR_MS;
+  if (endDate == null) {
+    return startDate + DAY_MS;
+  }
+  // ICS all-day DTEND is exclusive; same local date as DTSTART is zero-length.
+  if (formatDateOnlyLocal(endDate) <= formatDateOnlyLocal(startDate)) {
+    return startDate + DAY_MS;
+  }
+  return endDate;
 }
 
 function mapTransparency(availability: EventAvailability | undefined): 'OPAQUE' | 'TRANSPARENT' | null {
@@ -124,13 +131,14 @@ function mapTransparency(availability: EventAvailability | undefined): 'OPAQUE' 
   return 'OPAQUE';
 }
 
-function toRRule(rule: EventRecurrenceRule): string {
+function toRRule(rule: EventRecurrenceRule, isAllDay: boolean): string {
   const parts: string[] = [`FREQ=${rule.frequency.toUpperCase()}`, `INTERVAL=${Math.max(1, rule.interval ?? 1)}`];
 
   if (rule.count != null) {
     parts.push(`COUNT=${rule.count}`);
   } else if (rule.end != null) {
-    parts.push(`UNTIL=${formatDateTimeUtc(rule.end)}`);
+    // RFC 5545: UNTIL must match DTSTART value type (DATE vs DATE-TIME).
+    parts.push(`UNTIL=${isAllDay ? formatDateOnlyLocal(rule.end) : formatDateTimeUtc(rule.end)}`);
   }
 
   if (rule.byWeekDay != null && rule.byWeekDay.length > 0) {
@@ -218,6 +226,18 @@ export function escapeText(value: string): string {
     .replace(/;/g, '\\;')
     .replace(/,/g, '\\,')
     .replace(/\r\n|\n|\r/g, '\\n');
+}
+
+/**
+ * Formats a property parameter value per RFC 5545 §3.2.
+ * Values with COMMA, SEMICOLON, or COLON are quoted; DQUOTE and line breaks are sanitized.
+ */
+function formatParamValue(value: string): string {
+  const sanitized = value.replace(/[\r\n]+/g, ' ').replace(/"/g, "'");
+  if (/[;:,]/.test(sanitized)) {
+    return `"${sanitized}"`;
+  }
+  return sanitized;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add partial web support for `createEvent(...)`: returns an `.ics` `File` as `CreateEventResult.ics` (`id` is `null` on web)
- Export `downloadIcsFile(...)` helper for browser downloads
- Wire the example app Create event button to download the ICS on web

Closes: #139

## Test plan
- [ ] On web, call `createEvent` with a title and confirm `ics` is a `File` and `id` is `null`
- [ ] Confirm `downloadIcsFile(ics)` downloads a usable `.ics` that opens in a calendar app
- [ ] Confirm custom `icsFileName` is applied (and `.ics` is appended when missing)
- [ ] Confirm omitted `startDate`/`endDate` fall back to now / now+1h
- [ ] On Android/iOS, confirm `createEvent` still creates a native event and returns a real `id`
- [ ] Confirm `createEventWithPrompt` remains unimplemented on web