### PR TITLE
docs: mention web platform in plugin descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ![capacitor-calendar-logo](assets/images/text-logo.png)
 
-Full-featured Capacitor plugin for native calendar and reminders access. Manage permissions, create, modify, and delete events and reminders programmatically or via the native UI, query events within a given time period, and list all available calendars.
+Full-featured Capacitor plugin for calendar and reminders access on iOS, Android, and the web. On iOS and Android, manage permissions, create, modify, and delete events and reminders programmatically or via the native UI, query events in a date range, and list available calendars. On the web, create events as ICS files that users can add to their calendar.
 
 ## Core Features
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ebarooni/capacitor-calendar",
   "version": "8.5.0",
-  "description": "A capacitor plugin for managing calendar events on iOS and Android, with reminders support on iOS.",
+  "description": "A Capacitor plugin for managing calendar events on iOS, Android, and the web, with reminders support on iOS.",
   "author": "Ehsan Barooni",
   "license": "MIT",
   "homepage": "https://ebarooni.github.io/capacitor-calendar",


### PR DESCRIPTION
## Summary
- Update the npm package description and README intro to include web support alongside iOS and Android.
- Clarify that web event creation uses ICS files.

The GitHub About description was already updated to match.

## Test plan
- [x] Confirm `package.json` description names iOS, Android, and web
- [x] Confirm the README intro mentions ICS on web