### PR TITLE
feat: expose isPartOfSeries on listEventsInRange events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,14 +4,16 @@ This file provides instructions for AI coding agents working on the `ebarooni/ca
 
 ## Writing Style
 
-Use plain, direct language.
-
 - Follow ASD-STE100 Simplified Technical English for vocabulary and sentence structure.
 - Apply Zinsser's four principles of quality writing:
-  1. Simplicity: Use common words. Prefer short sentences.
-  2. Brevity: Remove words that do not add meaning.
+  1. Simplicity: Use common, plain words. Prefer short, direct sentences.
+  2. Brevity: Remove words that do not add meaning. Do not restate the same idea in a second sentence.
   3. Clarity: State one idea per sentence. Avoid ambiguity.
   4. Humanity: Write for a person, not a manual. Be direct and respectful.
+- For public API JSDoc:
+  - Prefer a one-line summary.
+  - Add a second sentence only when the name alone is ambiguous.
+  - Do not compare related fields unless the values interact.
 
 ## Important Rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Contents
 
 - [Version 8.x.x](#version-8xx)
+  - [8.6.0](#860)
   - [8.5.0](#850)
   - [8.4.0](#840)
   - [8.3.0](#830)
@@ -44,6 +45,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 # Version 8.x.x
 
 Changelogs for the versions supporting Capacitor 8.
+
+## 8.6.0
+
+### Added
+
+- `CalendarEvent.isPartOfSeries` on events returned by `listEventsInRange(...)` so apps can detect recurring-series membership (Android, iOS)
+- `ListEventsInRangeResult` for `listEventsInRange(...)`
 
 ## 8.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ Changelogs for the versions supporting Capacitor 8.
 - `CalendarEvent.isPartOfSeries` on events returned by `listEventsInRange(...)` so apps can detect recurring-series membership (Android, iOS)
 - `ListEventsInRangeResult` for `listEventsInRange(...)`
 
+### Fixed
+
+- `CreateEventResult.ics` is now always `null` on Android and iOS (was omitted / `undefined`)
+
 ## 8.5.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -248,48 +248,48 @@ See [CHANGELOG.md](CHANGELOG.md) for the latest updates and release history.
 
 <docgen-index>
 
-* [`checkPermission(...)`](#checkpermission)
-* [`checkAllPermissions()`](#checkallpermissions)
-* [`requestPermission(...)`](#requestpermission)
-* [`requestAllPermissions()`](#requestallpermissions)
-* [`requestWriteOnlyCalendarAccess()`](#requestwriteonlycalendaraccess)
-* [`requestReadOnlyCalendarAccess()`](#requestreadonlycalendaraccess)
-* [`requestFullCalendarAccess()`](#requestfullcalendaraccess)
-* [`requestFullRemindersAccess()`](#requestfullremindersaccess)
-* [`createEventWithPrompt(...)`](#createeventwithprompt)
-* [`modifyEventWithPrompt(...)`](#modifyeventwithprompt)
-* [`createEvent(...)`](#createevent)
-* [`modifyEvent(...)`](#modifyevent)
-* [`deleteEventsById(...)`](#deleteeventsbyid)
-* [`deleteEvent(...)`](#deleteevent)
-* [`deleteEventWithPrompt(...)`](#deleteeventwithprompt)
-* [`listEventsInRange(...)`](#listeventsinrange)
-* [`commit()`](#commit)
-* [`selectCalendarsWithPrompt(...)`](#selectcalendarswithprompt)
-* [`fetchAllCalendarSources()`](#fetchallcalendarsources)
-* [`listCalendars()`](#listcalendars)
-* [`getDefaultCalendar(...)`](#getdefaultcalendar)
-* [`openCalendar(...)`](#opencalendar)
-* [`createCalendar(...)`](#createcalendar)
-* [`deleteCalendar(...)`](#deletecalendar)
-* [`modifyCalendar(...)`](#modifycalendar)
-* [`createRemindersList(...)`](#createreminderslist)
-* [`deleteRemindersList(...)`](#deletereminderslist)
-* [`fetchAllRemindersSources()`](#fetchallreminderssources)
-* [`openReminders()`](#openreminders)
-* [`getDefaultRemindersList()`](#getdefaultreminderslist)
-* [`getRemindersLists()`](#getreminderslists)
-* [`createReminder(...)`](#createreminder)
-* [`deleteRemindersById(...)`](#deleteremindersbyid)
-* [`deleteReminder(...)`](#deletereminder)
-* [`modifyReminder(...)`](#modifyreminder)
-* [`getReminderById(...)`](#getreminderbyid)
-* [`getRemindersFromLists(...)`](#getremindersfromlists)
-* [`deleteReminderWithPrompt(...)`](#deletereminderwithprompt)
-* [`updateRemindersList(...)`](#updatereminderslist)
-* [Interfaces](#interfaces)
-* [Type Aliases](#type-aliases)
-* [Enums](#enums)
+- [`checkPermission(...)`](#checkpermission)
+- [`checkAllPermissions()`](#checkallpermissions)
+- [`requestPermission(...)`](#requestpermission)
+- [`requestAllPermissions()`](#requestallpermissions)
+- [`requestWriteOnlyCalendarAccess()`](#requestwriteonlycalendaraccess)
+- [`requestReadOnlyCalendarAccess()`](#requestreadonlycalendaraccess)
+- [`requestFullCalendarAccess()`](#requestfullcalendaraccess)
+- [`requestFullRemindersAccess()`](#requestfullremindersaccess)
+- [`createEventWithPrompt(...)`](#createeventwithprompt)
+- [`modifyEventWithPrompt(...)`](#modifyeventwithprompt)
+- [`createEvent(...)`](#createevent)
+- [`modifyEvent(...)`](#modifyevent)
+- [`deleteEventsById(...)`](#deleteeventsbyid)
+- [`deleteEvent(...)`](#deleteevent)
+- [`deleteEventWithPrompt(...)`](#deleteeventwithprompt)
+- [`listEventsInRange(...)`](#listeventsinrange)
+- [`commit()`](#commit)
+- [`selectCalendarsWithPrompt(...)`](#selectcalendarswithprompt)
+- [`fetchAllCalendarSources()`](#fetchallcalendarsources)
+- [`listCalendars()`](#listcalendars)
+- [`getDefaultCalendar(...)`](#getdefaultcalendar)
+- [`openCalendar(...)`](#opencalendar)
+- [`createCalendar(...)`](#createcalendar)
+- [`deleteCalendar(...)`](#deletecalendar)
+- [`modifyCalendar(...)`](#modifycalendar)
+- [`createRemindersList(...)`](#createreminderslist)
+- [`deleteRemindersList(...)`](#deletereminderslist)
+- [`fetchAllRemindersSources()`](#fetchallreminderssources)
+- [`openReminders()`](#openreminders)
+- [`getDefaultRemindersList()`](#getdefaultreminderslist)
+- [`getRemindersLists()`](#getreminderslists)
+- [`createReminder(...)`](#createreminder)
+- [`deleteRemindersById(...)`](#deleteremindersbyid)
+- [`deleteReminder(...)`](#deletereminder)
+- [`modifyReminder(...)`](#modifyreminder)
+- [`getReminderById(...)`](#getreminderbyid)
+- [`getRemindersFromLists(...)`](#getremindersfromlists)
+- [`deleteReminderWithPrompt(...)`](#deletereminderwithprompt)
+- [`updateRemindersList(...)`](#updatereminderslist)
+- [Interfaces](#interfaces)
+- [Type Aliases](#type-aliases)
+- [Enums](#enums)
 
 </docgen-index>
 
@@ -315,8 +315,7 @@ On Android, `readReminders` and `writeReminders` resolve to `"prompt"`.
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### checkAllPermissions()
 
@@ -333,8 +332,7 @@ On Android, reminder keys always resolve to `"prompt"`.
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### requestPermission(...)
 
@@ -355,8 +353,7 @@ On Android, `readReminders` and `writeReminders` reject with `Invalid scope.`
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### requestAllPermissions()
 
@@ -373,8 +370,7 @@ On Android, only calendar permissions are requested; reminder keys stay `"prompt
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### requestWriteOnlyCalendarAccess()
 
@@ -390,8 +386,7 @@ Requests write access to the calendar.
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### requestReadOnlyCalendarAccess()
 
@@ -407,8 +402,7 @@ Requests read access to the calendar.
 
 **Platform:** Android
 
---------------------
-
+---
 
 ### requestFullCalendarAccess()
 
@@ -424,8 +418,7 @@ Requests read and write access to the calendar.
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### requestFullRemindersAccess()
 
@@ -443,8 +436,7 @@ A grant covers both `readReminders` and `writeReminders`.
 
 **Platform:** iOS
 
---------------------
-
+---
 
 ### createEventWithPrompt(...)
 
@@ -466,8 +458,7 @@ Fetch the events to find the ID of the newly created event.
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### modifyEventWithPrompt(...)
 
@@ -488,8 +479,7 @@ On Android always returns `null`.
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### createEvent(...)
 
@@ -513,8 +503,7 @@ this method does not trigger a download.
 
 **Platform:** Android, iOS, Web
 
---------------------
-
+---
 
 ### modifyEvent(...)
 
@@ -532,8 +521,7 @@ Modifies an event.
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### deleteEventsById(...)
 
@@ -553,8 +541,7 @@ Deletes multiple events.
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### deleteEvent(...)
 
@@ -572,8 +559,7 @@ Deletes an event.
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### deleteEventWithPrompt(...)
 
@@ -593,8 +579,7 @@ Opens a dialog to delete an event.
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### listEventsInRange(...)
 
@@ -617,8 +602,7 @@ multi-day events that span the range without starting or ending inside it.
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### commit()
 
@@ -632,8 +616,7 @@ Saves pending calendar changes.
 
 **Platform:** iOS
 
---------------------
-
+---
 
 ### selectCalendarsWithPrompt(...)
 
@@ -662,8 +645,7 @@ call continues until the user confirms or cancels.
 
 **Platform:** iOS
 
---------------------
-
+---
 
 ### fetchAllCalendarSources()
 
@@ -682,8 +664,7 @@ an empty array. This method does not reject solely for missing permission.
 
 **Platform:** iOS
 
---------------------
-
+---
 
 ### listCalendars()
 
@@ -702,8 +683,7 @@ rejects. On iOS, missing authorization typically returns an empty `result`.
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### getDefaultCalendar(...)
 
@@ -731,8 +711,7 @@ Otherwise the method returns `null` when there is no system default.
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### openCalendar(...)
 
@@ -750,8 +729,7 @@ Opens the calendar app.
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### createCalendar(...)
 
@@ -774,8 +752,7 @@ On Android, `accountName` and `ownerAccount` are required at runtime.
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### deleteCalendar(...)
 
@@ -793,8 +770,7 @@ Deletes a calendar by id.
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### modifyCalendar(...)
 
@@ -812,8 +788,7 @@ Modifies a calendar with options.
 
 **Platform:** Android, iOS
 
---------------------
-
+---
 
 ### createRemindersList(...)
 
@@ -833,8 +808,7 @@ Creates a new reminders list.
 
 **Platform:** iOS
 
---------------------
-
+---
 
 ### deleteRemindersList(...)
 
@@ -852,8 +826,7 @@ Deletes a reminders list.
 
 **Platform:** iOS
 
---------------------
-
+---
 
 ### fetchAllRemindersSources()
 
@@ -869,8 +842,7 @@ Retrieves a list of calendar sources.
 
 **Platform:** iOS
 
---------------------
-
+---
 
 ### openReminders()
 
@@ -884,8 +856,7 @@ Opens the reminders app.
 
 **Platform:** iOS
 
---------------------
-
+---
 
 ### getDefaultRemindersList()
 
@@ -901,8 +872,7 @@ Retrieves the default reminders list.
 
 **Platform:** iOS
 
---------------------
-
+---
 
 ### getRemindersLists()
 
@@ -918,8 +888,7 @@ Retrieves all available reminders lists.
 
 **Platform:** iOS
 
---------------------
-
+---
 
 ### createReminder(...)
 
@@ -939,8 +908,7 @@ Creates a reminder.
 
 **Platform:** iOS
 
---------------------
-
+---
 
 ### deleteRemindersById(...)
 
@@ -960,8 +928,7 @@ Deletes multiple reminders.
 
 **Platform:** iOS
 
---------------------
-
+---
 
 ### deleteReminder(...)
 
@@ -979,8 +946,7 @@ Deletes a reminder.
 
 **Platform:** iOS
 
---------------------
-
+---
 
 ### modifyReminder(...)
 
@@ -998,8 +964,7 @@ Modifies a reminder.
 
 **Platform:** iOS
 
---------------------
-
+---
 
 ### getReminderById(...)
 
@@ -1019,8 +984,7 @@ Retrieve a reminder by ID.
 
 **Platform:** iOS
 
---------------------
-
+---
 
 ### getRemindersFromLists(...)
 
@@ -1040,8 +1004,7 @@ Retrieves reminders from multiple lists.
 
 **Platform:** iOS
 
---------------------
-
+---
 
 ### deleteReminderWithPrompt(...)
 
@@ -1061,8 +1024,7 @@ Opens a dialog to delete a reminder.
 
 **Platform:** iOS
 
---------------------
-
+---
 
 ### updateRemindersList(...)
 
@@ -1082,11 +1044,9 @@ Update a reminders list with options.
 
 **Platform:** iOS
 
---------------------
-
+---
 
 ### Interfaces
-
 
 #### CheckPermissionOptions
 
@@ -1096,7 +1056,6 @@ Options for {@link CalendarAccess#checkPermission}.
 | ----------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ------------ |
 | **`scope`** | <code><a href="#calendarpermissionscope">CalendarPermissionScope</a></code> | The permission scope to check. On Android, `readReminders` and `writeReminders` resolve to `"prompt"` (reminders are not supported on Android). | 8.3.1 | Android, iOS |
 
-
 #### RequestPermissionOptions
 
 Options for {@link CalendarAccess#requestPermission}.
@@ -1105,13 +1064,11 @@ Options for {@link CalendarAccess#requestPermission}.
 | ----------- | --------------------------------------------------------------------------- | -------------------------------- | ----- | ------------ |
 | **`scope`** | <code><a href="#calendarpermissionscope">CalendarPermissionScope</a></code> | The permission scope to request. | 8.3.1 | Android, iOS |
 
-
 #### CreateEventWithPromptResult
 
 | Prop     | Type                        | Description                                                                                        | Since | Platform     |
 | -------- | --------------------------- | -------------------------------------------------------------------------------------------------- | ----- | ------------ |
 | **`id`** | <code>string \| null</code> | The identifier of the created event. Always `null` on Android. Present on iOS when the user saves. | 0.1.0 | Android, iOS |
-
 
 #### CreateEventWithPromptOptions
 
@@ -1130,7 +1087,6 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`title`**        | <code>string</code>                                                 |                                                                                                                                                                                                  | 0.1.0 | Android, iOS |
 | **`url`**          | <code>string</code>                                                 |                                                                                                                                                                                                  | 0.1.0 | iOS          |
 
-
 #### EventRecurrenceRule
 
 | Prop                 | Type                                                                | Description                                                                                                                                                             | Default        | Since | Platform     |
@@ -1144,7 +1100,6 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`frequency`**      | <code><a href="#recurrencefrequency">RecurrenceFrequency</a></code> | How often the event repeats.                                                                                                                                            |                | 7.3.0 | Android, iOS |
 | **`interval`**       | <code>number</code>                                                 | The interval between recurrences. Use in combination with `frequency`. For example, a weekly event with an interval of 2, results in the event occurring every 2 weeks. | <code>1</code> | 7.3.0 | Android, iOS |
 | **`weeksOfTheYear`** | <code>number[]</code>                                               | Limits a yearly recurrence to specific ISO week numbers (1 to 53).                                                                                                      |                | 7.3.0 | iOS          |
-
 
 #### ModifyEventWithPromptOptions
 
@@ -1164,14 +1119,12 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`url`**          | <code>string</code>                                                 |                                                                                                                                                                                                  | 0.1.0 | iOS          |
 | **`id`**           | <code>string</code>                                                 | The ID of the event to be modified.                                                                                                                                                              | 7.1.0 | Android, iOS |
 
-
 #### CreateEventResult
 
 | Prop      | Type                        | Description                                                                                                                                                                                                                    | Since | Platform     |
 | --------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- | ------------ |
 | **`ics`** | <code>File \| null</code>   | An `.ics` file (`text/calendar`) with one `VEVENT`. Always `null` on Android and iOS. On Web, the plugin does not write to a calendar store or start a download; use `downloadIcsFile(...)` or pass the `File` to another API. | 8.5.0 | Web          |
 | **`id`**  | <code>string \| null</code> | The identifier of the created event. Always `null` on Web. Present on Android and iOS after a successful create.                                                                                                               | 0.4.0 | Android, iOS |
-
 
 #### CreateEventOptions
 
@@ -1195,14 +1148,12 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`title`**        | <code>string</code>                                                 |                                                                                                                                                                       |                   | 0.4.0 | Android, iOS, Web |
 | **`url`**          | <code>string</code>                                                 |                                                                                                                                                                       |                   | 0.1.0 | iOS, Web          |
 
-
 #### EventGuest
 
 | Prop        | Type                | Since |
 | ----------- | ------------------- | ----- |
 | **`name`**  | <code>string</code> | 7.1.0 |
 | **`email`** | <code>string</code> | 7.1.0 |
-
 
 #### ModifyEventOptions
 
@@ -1226,14 +1177,12 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`title`**        | <code>string</code>                                                 |                                                                                                                                                        |                                   | 0.4.0 | Android, iOS |
 | **`url`**          | <code>string</code>                                                 |                                                                                                                                                        |                                   | 0.1.0 | iOS          |
 
-
 #### DeleteEventsByIdResult
 
 | Prop          | Type                  | Since |
 | ------------- | --------------------- | ----- |
 | **`deleted`** | <code>string[]</code> | 7.1.0 |
 | **`failed`**  | <code>string[]</code> | 7.1.0 |
-
 
 #### DeleteEventsByIdOptions
 
@@ -1243,7 +1192,6 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`ids`**    | <code>string[]</code>                           |                                                                                                                                                                                                                                  |                                   | 7.1.0 |              |
 | **`span`**   | <code><a href="#eventspan">EventSpan</a></code> | How much of a recurring series to delete. On Android, `THIS_EVENT` cannot target a single recurring occurrence here — use `deleteEvent` with `instanceDate`. Those ids are reported in `failed`.                                 | <code>EventSpan.THIS_EVENT</code> | 7.1.0 | Android, iOS |
 
-
 #### DeleteEventOptions
 
 | Prop               | Type                                            | Description                                                                                                                                                                                                                                              | Default                           | Since | Platform     |
@@ -1252,7 +1200,6 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`id`**           | <code>string</code>                             | The ID of the event to delete.                                                                                                                                                                                                                           |                                   | 7.1.0 | Android, iOS |
 | **`instanceDate`** | <code>number</code>                             | The start time of the occurrence to delete, in milliseconds since the epoch. Use `startDate` from `listEventsInRange`. On Android, required for `THIS_EVENT` on recurring events. If omitted with `THIS_AND_FUTURE_EVENTS`, the whole series is deleted. |                                   | 8.3.0 | Android      |
 | **`span`**         | <code><a href="#eventspan">EventSpan</a></code> | How much of a recurring series to delete.                                                                                                                                                                                                                | <code>EventSpan.THIS_EVENT</code> | 7.1.0 | Android, iOS |
-
 
 #### DeleteEventWithPromptOptions
 
@@ -1267,13 +1214,11 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`span`**              | <code><a href="#eventspan">EventSpan</a></code> | How much of a recurring series to delete.                                                                                                                                                                                                                | <code>EventSpan.THIS_EVENT</code> | 7.1.0 | Android, iOS |
 | **`title`**             | <code>string</code>                             | Title of the dialog.                                                                                                                                                                                                                                     |                                   | 7.1.0 | Android, iOS |
 
-
 #### ListEventsInRangeResult
 
 | Prop         | Type                         | Description                              | Since | Platform     |
 | ------------ | ---------------------------- | ---------------------------------------- | ----- | ------------ |
 | **`result`** | <code>CalendarEvent[]</code> | Events that overlap the requested range. | 8.6.0 | Android, iOS |
-
 
 #### CalendarEvent
 
@@ -1302,7 +1247,6 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`attendees`**                 | <code>{ email: string \| null; name: string \| null; role: <a href="#attendeerole">AttendeeRole</a> \| null; status: <a href="#attendeestatus">AttendeeStatus</a> \| null; type: <a href="#attendeetype">AttendeeType</a> \| null; }[]</code> |                                                                                                                                                                                            | 7.1.0 | Android, iOS |
 | **`timezone`**                  | <code>string \| null</code>                                                                                                                                                                                                                   |                                                                                                                                                                                            | 7.1.0 | Android, iOS |
 
-
 #### ListEventsInRangeOptions
 
 | Prop       | Type                | Description                                                                                                                                                                             | Since |
@@ -1310,13 +1254,11 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`from`** | <code>number</code> | The start of the range, in milliseconds since the epoch. Events still in progress at this time are included.                                                                            | 7.1.0 |
 | **`to`**   | <code>number</code> | The end of the range, in milliseconds since the epoch. Events that begin at or after this time are typically excluded; prefer the next day's start when querying a single calendar day. | 7.1.0 |
 
-
 #### SelectCalendarsWithPromptResult
 
 | Prop         | Type                    | Description                                                               | Since | Platform |
 | ------------ | ----------------------- | ------------------------------------------------------------------------- | ----- | -------- |
 | **`result`** | <code>Calendar[]</code> | Calendars the user confirmed in the chooser. Empty when the user cancels. | 8.4.0 | iOS      |
-
 
 #### Calendar
 
@@ -1337,7 +1279,6 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`maxReminders`**               | <code>number \| null</code>                                       | Maximum number of reminders allowed per event.                                                                                                                                                 | 7.1.0 | Android      |
 | **`location`**                   | <code>string \| null</code>                                       |                                                                                                                                                                                                | 7.1.0 | Android      |
 
-
 #### CalendarSource
 
 | Prop        | Type                                                              | Since | Platform |
@@ -1346,7 +1287,6 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`id`**    | <code>string</code>                                               | 7.1.0 | iOS      |
 | **`title`** | <code>string</code>                                               | 7.1.0 | iOS      |
 
-
 #### SelectCalendarsWithPromptOptions
 
 | Prop               | Type                                                                                | Description                | Default                                                | Since |
@@ -1354,13 +1294,11 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`displayStyle`** | <code><a href="#calendarchooserdisplaystyle">CalendarChooserDisplayStyle</a></code> |                            | <code>CalendarChooserDisplayStyle.ALL_CALENDARS</code> | 7.1.0 |
 | **`multiple`**     | <code>boolean</code>                                                                | Allow multiple selections. | <code>false</code>                                     | 7.1.0 |
 
-
 #### FetchAllCalendarSourcesResult
 
 | Prop         | Type                          | Description                                        | Since | Platform |
 | ------------ | ----------------------------- | -------------------------------------------------- | ----- | -------- |
 | **`result`** | <code>CalendarSource[]</code> | All calendar sources (accounts) known to EventKit. | 8.4.0 | iOS      |
-
 
 #### ListCalendarsResult
 
@@ -1368,13 +1306,11 @@ Options for {@link CalendarAccess#requestPermission}.
 | ------------ | ----------------------- | ------------------------ | ----- | ------------ |
 | **`result`** | <code>Calendar[]</code> | All available calendars. | 8.4.0 | Android, iOS |
 
-
 #### GetDefaultCalendarOptions
 
 | Prop                      | Type                 | Description                                                                 | Default            | Since | Platform     |
 | ------------------------- | -------------------- | --------------------------------------------------------------------------- | ------------------ | ----- | ------------ |
 | **`useFallbackCalendar`** | <code>boolean</code> | When there is no system default calendar, use the first available calendar. | <code>false</code> | 8.4.0 | Android, iOS |
-
 
 #### OpenCalendarOptions
 
@@ -1382,13 +1318,11 @@ Options for {@link CalendarAccess#requestPermission}.
 | ---------- | ------------------- | ------------------------------------------------------------------ | ----------------------- | ----- | ------------ |
 | **`date`** | <code>number</code> | The date to open the calendar at, in milliseconds since the epoch. | <code>Date.now()</code> | 7.1.0 | Android, iOS |
 
-
 #### CreateCalendarResult
 
 | Prop     | Type                | Description                               | Since | Platform     |
 | -------- | ------------------- | ----------------------------------------- | ----- | ------------ |
 | **`id`** | <code>string</code> | Identifier of the newly created calendar. | 8.4.0 | Android, iOS |
-
 
 #### CreateCalendarOptions
 
@@ -1400,13 +1334,11 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`accountName`**  | <code>string</code> | The account under which the calendar is registered. Required on Android. Typically an email address.                                                                                                                       |                      | 7.1.0 | Android      |
 | **`ownerAccount`** | <code>string</code> | The owner of the calendar. Required on Android. Typically an email address.                                                                                                                                                |                      | 7.1.0 | Android      |
 
-
 #### DeleteCalendarOptions
 
 | Prop     | Type                | Since | Platform     |
 | -------- | ------------------- | ----- | ------------ |
 | **`id`** | <code>string</code> | 7.1.0 | Android, iOS |
-
 
 #### ModifyCalendarOptions
 
@@ -1416,13 +1348,11 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`title`** | <code>string</code> | Display title of the calendar. On Android this updates both `CALENDAR_DISPLAY_NAME` (`title`) and `Calendars.NAME` (`internalTitle`). | 7.2.0 | Android, iOS |
 | **`color`** | <code>string</code> | The color of the calendar as `#RRGGBB` or `#RRGGBBAA`.                                                                                | 7.2.0 | Android, iOS |
 
-
 #### CreateRemindersListResult
 
 | Prop     | Type                | Description                                     | Since | Platform |
 | -------- | ------------------- | ----------------------------------------------- | ----- | -------- |
 | **`id`** | <code>string</code> | Identifier of the newly created reminders list. | 8.1.0 | iOS      |
-
 
 #### CreateRemindersListOptions
 
@@ -1433,14 +1363,12 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`sourceId`** | <code>string</code>                                                                                                              | The EKSource identifier (account) where the list should be created. If left undefined, iCloud will be used if available, otherwise falls back to local.                                                                      |                     | 8.1.0 | iOS      |
 | **`title`**    | <code>string</code>                                                                                                              | The title of the list.                                                                                                                                                                                                       |                     | 8.1.0 | iOS      |
 
-
 #### DeleteRemindersListOptions
 
 | Prop         | Type                 | Description                                                                                                                                                                                                                      | Default           | Since | Platform |
 | ------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | ----- | -------- |
 | **`commit`** | <code>boolean</code> | Whether to save the deletion to the event store immediately. Pass `false` to batch multiple changes and commit them together using `CapacitorCalendar.commit()`, which is more efficient than committing each save individually. | <code>true</code> | 8.2.0 | iOS      |
 | **`id`**     | <code>string</code>  | Identifier of the reminders list to delete.                                                                                                                                                                                      |                   | 8.2.0 | iOS      |
-
 
 #### CreateReminderOptions
 
@@ -1459,7 +1387,6 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`recurrence`**     | <code><a href="#recurrencerule">RecurrenceRule</a></code> |                                                                                                                                                           | 7.1.0 |
 | **`alerts`**         | <code>number[]</code>                                     | Alert times in minutes relative to the reminder start. Use negative numbers for alerts before the start, and positive numbers for alerts after the start. | 7.1.0 |
 
-
 #### RecurrenceRule
 
 | Prop            | Type                                                                | Description                                                                        | Since |
@@ -1468,7 +1395,6 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`interval`**  | <code>number</code>                                                 | How often it repeats (e.g. 1 for every occurrence, 2 for every second occurrence). | 7.1.0 |
 | **`end`**       | <code>number</code>                                                 | Timestamp of when the recurrence ends.                                             | 7.1.0 |
 
-
 #### DeleteRemindersByIdResult
 
 | Prop          | Type                  | Since |
@@ -1476,20 +1402,17 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`deleted`** | <code>string[]</code> | 7.1.0 |
 | **`failed`**  | <code>string[]</code> | 7.1.0 |
 
-
 #### DeleteRemindersByIdOptions
 
 | Prop      | Type                  | Since |
 | --------- | --------------------- | ----- |
 | **`ids`** | <code>string[]</code> | 7.1.0 |
 
-
 #### DeleteReminderOptions
 
 | Prop     | Type                | Since |
 | -------- | ------------------- | ----- |
 | **`id`** | <code>string</code> | 7.1.0 |
-
 
 #### ModifyReminderOptions
 
@@ -1509,7 +1432,6 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`recurrence`**     | <code><a href="#recurrencerule">RecurrenceRule</a></code> |                                                                                                                                                                                               | 7.1.0 |
 | **`alerts`**         | <code>number[]</code>                                     | Alert times in minutes relative to the reminder start. Use negative numbers for alerts before the start, and positive numbers for alerts after the start. On iOS only 2 alerts are supported. | 7.1.0 |
 
-
 #### Reminder
 
 | Prop                 | Type                          | Since |
@@ -1528,20 +1450,17 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`recurrence`**     | <code>RecurrenceRule[]</code> | 7.1.0 |
 | **`alerts`**         | <code>number[]</code>         | 7.1.0 |
 
-
 #### GetReminderByIdOptions
 
 | Prop     | Type                | Since |
 | -------- | ------------------- | ----- |
 | **`id`** | <code>string</code> | 7.1.0 |
 
-
 #### GetRemindersFromListsOptions
 
 | Prop          | Type                  | Since |
 | ------------- | --------------------- | ----- |
 | **`listIds`** | <code>string[]</code> | 7.1.0 |
-
 
 #### DeleteReminderWithPromptOptions
 
@@ -1553,13 +1472,11 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`confirmButtonText`** | <code>string</code> | Text to show on the confirm button. | <code>'Delete'</code> | 7.2.0 |
 | **`cancelButtonText`**  | <code>string</code> | Text to show on the cancel button.  | <code>'Cancel'</code> | 7.2.0 |
 
-
 #### UpdateRemindersListResult
 
 | Prop     | Type                | Description                               | Since | Platform |
 | -------- | ------------------- | ----------------------------------------- | ----- | -------- |
 | **`id`** | <code>string</code> | Identifier of the updated reminders list. | 8.2.0 | iOS      |
-
 
 #### UpdateRemindersListOptions
 
@@ -1570,49 +1487,48 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`id`**     | <code>string</code>                                                                                                              | The identifier of the list to update.                                                                                                                                                                                   |                   | 8.2.0 | iOS      |
 | **`title`**  | <code>string</code>                                                                                                              | The new title of the list. If omitted, the title is left unchanged.                                                                                                                                                     |                   | 8.2.0 | iOS      |
 
-
 ### Type Aliases
-
 
 #### PermissionState
 
 <code>'prompt' | 'prompt-with-rationale' | 'granted' | 'denied'</code>
 
-
 #### CheckAllPermissionsResult
 
-<code><a href="#record">Record</a>&lt;<a href="#calendarpermissionscope">CalendarPermissionScope</a>, <a href="#permissionstate">PermissionState</a>&gt;</code>
-
+<code>
+  <a href="#record">Record</a>&lt;<a href="#calendarpermissionscope">CalendarPermissionScope</a>,{' '}
+  <a href="#permissionstate">PermissionState</a>&gt;
+</code>
 
 #### Record
 
 Construct a type with a set of properties K of type T
 
-<code>{ [P in K]: T; }</code>
-
+<code>{
+ [P in K]: T;
+ }</code>
 
 #### RequestAllPermissionsResult
 
-<code><a href="#checkallpermissionsresult">CheckAllPermissionsResult</a></code>
-
+<code>
+  <a href="#checkallpermissionsresult">CheckAllPermissionsResult</a>
+</code>
 
 #### RecurrenceFrequency
 
 <code>'daily' | 'weekly' | 'monthly' | 'yearly'</code>
 
-
 #### EventEditAction
 
 <code>'canceled' | 'saved' | 'deleted'</code>
 
-
 #### RemindersList
 
-<code><a href="#calendar">Calendar</a></code>
-
+<code>
+  <a href="#calendar">Calendar</a>
+</code>
 
 ### Enums
-
 
 #### CalendarPermissionScope
 
@@ -1622,7 +1538,6 @@ Construct a type with a set of properties K of type T
 | **`READ_REMINDERS`**  | <code>'readReminders'</code>  | Permission required for reading reminders. On Android, reminders are not supported. `checkPermission` and `checkAllPermissions` return `"prompt"` for this scope. `requestPermission` rejects with `Invalid scope.`.             | 7.1.0 | iOS          |
 | **`WRITE_CALENDAR`**  | <code>'writeCalendar'</code>  | Permission required for adding or modifying calendar events.                                                                                                                                                                     | 7.1.0 | Android, iOS |
 | **`WRITE_REMINDERS`** | <code>'writeReminders'</code> | Permission required for adding or modifying reminders. On Android, reminders are not supported. `checkPermission` and `checkAllPermissions` return `"prompt"` for this scope. `requestPermission` rejects with `Invalid scope.`. | 7.1.0 | iOS          |
-
 
 #### EventAvailability
 
@@ -1634,14 +1549,12 @@ Construct a type with a set of properties K of type T
 | **`TENTATIVE`**     |                 | 7.1.0 | Android, iOS |
 | **`UNAVAILABLE`**   |                 | 7.1.0 | iOS          |
 
-
 #### EventSpan
 
 | Members                      | Description                                                     | Since |
 | ---------------------------- | --------------------------------------------------------------- | ----- |
 | **`THIS_EVENT`**             | Only the identified event or occurrence.                        | 7.1.0 |
 | **`THIS_AND_FUTURE_EVENTS`** | The identified occurrence and future occurrences in the series. | 7.1.0 |
-
 
 #### EventStatus
 
@@ -1651,7 +1564,6 @@ Construct a type with a set of properties K of type T
 | **`CONFIRMED`** | <code>'confirmed'</code> | 7.1.0 | Android, iOS |
 | **`TENTATIVE`** | <code>'tentative'</code> | 7.1.0 | Android, iOS |
 | **`CANCELED`**  | <code>'canceled'</code>  | 7.1.0 | Android, iOS |
-
 
 #### AttendeeRole
 
@@ -1666,7 +1578,6 @@ Construct a type with a set of properties K of type T
 | **`ORGANIZER`**       | <code>'organizer'</code>      | 7.1.0 | Android      |
 | **`PERFORMER`**       | <code>'performer'</code>      | 7.1.0 | Android      |
 | **`SPEAKER`**         | <code>'speaker'</code>        | 7.1.0 | Android      |
-
 
 #### AttendeeStatus
 
@@ -1683,7 +1594,6 @@ Construct a type with a set of properties K of type T
 | **`COMPLETED`**  | <code>'completed'</code> | 7.1.0 | iOS          |
 | **`IN_PROCESS`** | <code>'inProcess'</code> | 7.1.0 | iOS          |
 
-
 #### AttendeeType
 
 | Members        | Value                   | Since | Platform     |
@@ -1697,7 +1607,6 @@ Construct a type with a set of properties K of type T
 | **`NONE`**     | <code>'none'</code>     | 7.1.0 | Android      |
 | **`OPTIONAL`** | <code>'optional'</code> | 7.1.0 | Android      |
 
-
 #### CalendarType
 
 | Members            | Since |
@@ -1707,7 +1616,6 @@ Construct a type with a set of properties K of type T
 | **`EXCHANGE`**     | 7.1.0 |
 | **`SUBSCRIPTION`** | 7.1.0 |
 | **`BIRTHDAY`**     | 7.1.0 |
-
 
 #### CalendarSourceType
 
@@ -1719,7 +1627,6 @@ Construct a type with a set of properties K of type T
 | **`MOBILE_ME`**  | 7.1.0 |
 | **`SUBSCRIBED`** | 7.1.0 |
 | **`BIRTHDAYS`**  | 7.1.0 |
-
 
 #### CalendarChooserDisplayStyle
 

--- a/README.md
+++ b/README.md
@@ -248,48 +248,48 @@ See [CHANGELOG.md](CHANGELOG.md) for the latest updates and release history.
 
 <docgen-index>
 
-- [`checkPermission(...)`](#checkpermission)
-- [`checkAllPermissions()`](#checkallpermissions)
-- [`requestPermission(...)`](#requestpermission)
-- [`requestAllPermissions()`](#requestallpermissions)
-- [`requestWriteOnlyCalendarAccess()`](#requestwriteonlycalendaraccess)
-- [`requestReadOnlyCalendarAccess()`](#requestreadonlycalendaraccess)
-- [`requestFullCalendarAccess()`](#requestfullcalendaraccess)
-- [`requestFullRemindersAccess()`](#requestfullremindersaccess)
-- [`createEventWithPrompt(...)`](#createeventwithprompt)
-- [`modifyEventWithPrompt(...)`](#modifyeventwithprompt)
-- [`createEvent(...)`](#createevent)
-- [`modifyEvent(...)`](#modifyevent)
-- [`deleteEventsById(...)`](#deleteeventsbyid)
-- [`deleteEvent(...)`](#deleteevent)
-- [`deleteEventWithPrompt(...)`](#deleteeventwithprompt)
-- [`listEventsInRange(...)`](#listeventsinrange)
-- [`commit()`](#commit)
-- [`selectCalendarsWithPrompt(...)`](#selectcalendarswithprompt)
-- [`fetchAllCalendarSources()`](#fetchallcalendarsources)
-- [`listCalendars()`](#listcalendars)
-- [`getDefaultCalendar(...)`](#getdefaultcalendar)
-- [`openCalendar(...)`](#opencalendar)
-- [`createCalendar(...)`](#createcalendar)
-- [`deleteCalendar(...)`](#deletecalendar)
-- [`modifyCalendar(...)`](#modifycalendar)
-- [`createRemindersList(...)`](#createreminderslist)
-- [`deleteRemindersList(...)`](#deletereminderslist)
-- [`fetchAllRemindersSources()`](#fetchallreminderssources)
-- [`openReminders()`](#openreminders)
-- [`getDefaultRemindersList()`](#getdefaultreminderslist)
-- [`getRemindersLists()`](#getreminderslists)
-- [`createReminder(...)`](#createreminder)
-- [`deleteRemindersById(...)`](#deleteremindersbyid)
-- [`deleteReminder(...)`](#deletereminder)
-- [`modifyReminder(...)`](#modifyreminder)
-- [`getReminderById(...)`](#getreminderbyid)
-- [`getRemindersFromLists(...)`](#getremindersfromlists)
-- [`deleteReminderWithPrompt(...)`](#deletereminderwithprompt)
-- [`updateRemindersList(...)`](#updatereminderslist)
-- [Interfaces](#interfaces)
-- [Type Aliases](#type-aliases)
-- [Enums](#enums)
+* [`checkPermission(...)`](#checkpermission)
+* [`checkAllPermissions()`](#checkallpermissions)
+* [`requestPermission(...)`](#requestpermission)
+* [`requestAllPermissions()`](#requestallpermissions)
+* [`requestWriteOnlyCalendarAccess()`](#requestwriteonlycalendaraccess)
+* [`requestReadOnlyCalendarAccess()`](#requestreadonlycalendaraccess)
+* [`requestFullCalendarAccess()`](#requestfullcalendaraccess)
+* [`requestFullRemindersAccess()`](#requestfullremindersaccess)
+* [`createEventWithPrompt(...)`](#createeventwithprompt)
+* [`modifyEventWithPrompt(...)`](#modifyeventwithprompt)
+* [`createEvent(...)`](#createevent)
+* [`modifyEvent(...)`](#modifyevent)
+* [`deleteEventsById(...)`](#deleteeventsbyid)
+* [`deleteEvent(...)`](#deleteevent)
+* [`deleteEventWithPrompt(...)`](#deleteeventwithprompt)
+* [`listEventsInRange(...)`](#listeventsinrange)
+* [`commit()`](#commit)
+* [`selectCalendarsWithPrompt(...)`](#selectcalendarswithprompt)
+* [`fetchAllCalendarSources()`](#fetchallcalendarsources)
+* [`listCalendars()`](#listcalendars)
+* [`getDefaultCalendar(...)`](#getdefaultcalendar)
+* [`openCalendar(...)`](#opencalendar)
+* [`createCalendar(...)`](#createcalendar)
+* [`deleteCalendar(...)`](#deletecalendar)
+* [`modifyCalendar(...)`](#modifycalendar)
+* [`createRemindersList(...)`](#createreminderslist)
+* [`deleteRemindersList(...)`](#deletereminderslist)
+* [`fetchAllRemindersSources()`](#fetchallreminderssources)
+* [`openReminders()`](#openreminders)
+* [`getDefaultRemindersList()`](#getdefaultreminderslist)
+* [`getRemindersLists()`](#getreminderslists)
+* [`createReminder(...)`](#createreminder)
+* [`deleteRemindersById(...)`](#deleteremindersbyid)
+* [`deleteReminder(...)`](#deletereminder)
+* [`modifyReminder(...)`](#modifyreminder)
+* [`getReminderById(...)`](#getreminderbyid)
+* [`getRemindersFromLists(...)`](#getremindersfromlists)
+* [`deleteReminderWithPrompt(...)`](#deletereminderwithprompt)
+* [`updateRemindersList(...)`](#updatereminderslist)
+* [Interfaces](#interfaces)
+* [Type Aliases](#type-aliases)
+* [Enums](#enums)
 
 </docgen-index>
 
@@ -315,7 +315,8 @@ On Android, `readReminders` and `writeReminders` resolve to `"prompt"`.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### checkAllPermissions()
 
@@ -332,7 +333,8 @@ On Android, reminder keys always resolve to `"prompt"`.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### requestPermission(...)
 
@@ -353,7 +355,8 @@ On Android, `readReminders` and `writeReminders` reject with `Invalid scope.`
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### requestAllPermissions()
 
@@ -370,7 +373,8 @@ On Android, only calendar permissions are requested; reminder keys stay `"prompt
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### requestWriteOnlyCalendarAccess()
 
@@ -386,7 +390,8 @@ Requests write access to the calendar.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### requestReadOnlyCalendarAccess()
 
@@ -402,7 +407,8 @@ Requests read access to the calendar.
 
 **Platform:** Android
 
----
+--------------------
+
 
 ### requestFullCalendarAccess()
 
@@ -418,7 +424,8 @@ Requests read and write access to the calendar.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### requestFullRemindersAccess()
 
@@ -436,7 +443,8 @@ A grant covers both `readReminders` and `writeReminders`.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### createEventWithPrompt(...)
 
@@ -458,7 +466,8 @@ Fetch the events to find the ID of the newly created event.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### modifyEventWithPrompt(...)
 
@@ -479,7 +488,8 @@ On Android always returns `null`.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### createEvent(...)
 
@@ -503,7 +513,8 @@ this method does not trigger a download.
 
 **Platform:** Android, iOS, Web
 
----
+--------------------
+
 
 ### modifyEvent(...)
 
@@ -521,7 +532,8 @@ Modifies an event.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### deleteEventsById(...)
 
@@ -541,7 +553,8 @@ Deletes multiple events.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### deleteEvent(...)
 
@@ -559,7 +572,8 @@ Deletes an event.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### deleteEventWithPrompt(...)
 
@@ -579,12 +593,13 @@ Opens a dialog to delete an event.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### listEventsInRange(...)
 
 ```typescript
-listEventsInRange(options: ListEventsInRangeOptions) => Promise<{ result: CalendarEvent[]; }>
+listEventsInRange(options: ListEventsInRangeOptions) => Promise<ListEventsInRangeResult>
 ```
 
 Retrieves events that overlap a date range.
@@ -596,13 +611,14 @@ multi-day events that span the range without starting or ending inside it.
 | ------------- | ----------------------------------------------------------------------------- |
 | **`options`** | <code><a href="#listeventsinrangeoptions">ListEventsInRangeOptions</a></code> |
 
-**Returns:** <code>Promise&lt;{ result: CalendarEvent[]; }&gt;</code>
+**Returns:** <code>Promise&lt;<a href="#listeventsinrangeresult">ListEventsInRangeResult</a>&gt;</code>
 
 **Since:** 0.10.0
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### commit()
 
@@ -616,7 +632,8 @@ Saves pending calendar changes.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### selectCalendarsWithPrompt(...)
 
@@ -645,7 +662,8 @@ call continues until the user confirms or cancels.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### fetchAllCalendarSources()
 
@@ -664,7 +682,8 @@ an empty array. This method does not reject solely for missing permission.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### listCalendars()
 
@@ -683,7 +702,8 @@ rejects. On iOS, missing authorization typically returns an empty `result`.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### getDefaultCalendar(...)
 
@@ -711,7 +731,8 @@ Otherwise the method returns `null` when there is no system default.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### openCalendar(...)
 
@@ -729,7 +750,8 @@ Opens the calendar app.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### createCalendar(...)
 
@@ -752,7 +774,8 @@ On Android, `accountName` and `ownerAccount` are required at runtime.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### deleteCalendar(...)
 
@@ -770,7 +793,8 @@ Deletes a calendar by id.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### modifyCalendar(...)
 
@@ -788,7 +812,8 @@ Modifies a calendar with options.
 
 **Platform:** Android, iOS
 
----
+--------------------
+
 
 ### createRemindersList(...)
 
@@ -808,7 +833,8 @@ Creates a new reminders list.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### deleteRemindersList(...)
 
@@ -826,7 +852,8 @@ Deletes a reminders list.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### fetchAllRemindersSources()
 
@@ -842,7 +869,8 @@ Retrieves a list of calendar sources.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### openReminders()
 
@@ -856,7 +884,8 @@ Opens the reminders app.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### getDefaultRemindersList()
 
@@ -872,7 +901,8 @@ Retrieves the default reminders list.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### getRemindersLists()
 
@@ -888,7 +918,8 @@ Retrieves all available reminders lists.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### createReminder(...)
 
@@ -908,7 +939,8 @@ Creates a reminder.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### deleteRemindersById(...)
 
@@ -928,7 +960,8 @@ Deletes multiple reminders.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### deleteReminder(...)
 
@@ -946,7 +979,8 @@ Deletes a reminder.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### modifyReminder(...)
 
@@ -964,7 +998,8 @@ Modifies a reminder.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### getReminderById(...)
 
@@ -984,7 +1019,8 @@ Retrieve a reminder by ID.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### getRemindersFromLists(...)
 
@@ -1004,7 +1040,8 @@ Retrieves reminders from multiple lists.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### deleteReminderWithPrompt(...)
 
@@ -1024,7 +1061,8 @@ Opens a dialog to delete a reminder.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### updateRemindersList(...)
 
@@ -1044,9 +1082,11 @@ Update a reminders list with options.
 
 **Platform:** iOS
 
----
+--------------------
+
 
 ### Interfaces
+
 
 #### CheckPermissionOptions
 
@@ -1056,6 +1096,7 @@ Options for {@link CalendarAccess#checkPermission}.
 | ----------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ------------ |
 | **`scope`** | <code><a href="#calendarpermissionscope">CalendarPermissionScope</a></code> | The permission scope to check. On Android, `readReminders` and `writeReminders` resolve to `"prompt"` (reminders are not supported on Android). | 8.3.1 | Android, iOS |
 
+
 #### RequestPermissionOptions
 
 Options for {@link CalendarAccess#requestPermission}.
@@ -1064,11 +1105,13 @@ Options for {@link CalendarAccess#requestPermission}.
 | ----------- | --------------------------------------------------------------------------- | -------------------------------- | ----- | ------------ |
 | **`scope`** | <code><a href="#calendarpermissionscope">CalendarPermissionScope</a></code> | The permission scope to request. | 8.3.1 | Android, iOS |
 
+
 #### CreateEventWithPromptResult
 
 | Prop     | Type                        | Description                                                                                        | Since | Platform     |
 | -------- | --------------------------- | -------------------------------------------------------------------------------------------------- | ----- | ------------ |
 | **`id`** | <code>string \| null</code> | The identifier of the created event. Always `null` on Android. Present on iOS when the user saves. | 0.1.0 | Android, iOS |
+
 
 #### CreateEventWithPromptOptions
 
@@ -1087,6 +1130,7 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`title`**        | <code>string</code>                                                 |                                                                                                                                                                                                  | 0.1.0 | Android, iOS |
 | **`url`**          | <code>string</code>                                                 |                                                                                                                                                                                                  | 0.1.0 | iOS          |
 
+
 #### EventRecurrenceRule
 
 | Prop                 | Type                                                                | Description                                                                                                                                                             | Default        | Since | Platform     |
@@ -1100,6 +1144,7 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`frequency`**      | <code><a href="#recurrencefrequency">RecurrenceFrequency</a></code> | How often the event repeats.                                                                                                                                            |                | 7.3.0 | Android, iOS |
 | **`interval`**       | <code>number</code>                                                 | The interval between recurrences. Use in combination with `frequency`. For example, a weekly event with an interval of 2, results in the event occurring every 2 weeks. | <code>1</code> | 7.3.0 | Android, iOS |
 | **`weeksOfTheYear`** | <code>number[]</code>                                               | Limits a yearly recurrence to specific ISO week numbers (1 to 53).                                                                                                      |                | 7.3.0 | iOS          |
+
 
 #### ModifyEventWithPromptOptions
 
@@ -1119,12 +1164,14 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`url`**          | <code>string</code>                                                 |                                                                                                                                                                                                  | 0.1.0 | iOS          |
 | **`id`**           | <code>string</code>                                                 | The ID of the event to be modified.                                                                                                                                                              | 7.1.0 | Android, iOS |
 
+
 #### CreateEventResult
 
-| Prop      | Type                        | Description                                                                                                                                                                                               | Since | Platform     |
-| --------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ------------ |
-| **`ics`** | <code>File</code>           | An `.ics` file (`text/calendar`) with one `VEVENT`. Present only on Web. The plugin does not write to a calendar store or start a download; use `downloadIcsFile(...)` or pass the `File` to another API. | 8.5.0 | Web          |
-| **`id`**  | <code>string \| null</code> | The identifier of the created event. Always `null` on Web. Present on Android and iOS after a successful create.                                                                                          | 0.4.0 | Android, iOS |
+| Prop      | Type                        | Description                                                                                                                                                                                                                    | Since | Platform     |
+| --------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- | ------------ |
+| **`ics`** | <code>File \| null</code>   | An `.ics` file (`text/calendar`) with one `VEVENT`. Always `null` on Android and iOS. On Web, the plugin does not write to a calendar store or start a download; use `downloadIcsFile(...)` or pass the `File` to another API. | 8.5.0 | Web          |
+| **`id`**  | <code>string \| null</code> | The identifier of the created event. Always `null` on Web. Present on Android and iOS after a successful create.                                                                                                               | 0.4.0 | Android, iOS |
+
 
 #### CreateEventOptions
 
@@ -1148,12 +1195,14 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`title`**        | <code>string</code>                                                 |                                                                                                                                                                       |                   | 0.4.0 | Android, iOS, Web |
 | **`url`**          | <code>string</code>                                                 |                                                                                                                                                                       |                   | 0.1.0 | iOS, Web          |
 
+
 #### EventGuest
 
 | Prop        | Type                | Since |
 | ----------- | ------------------- | ----- |
 | **`name`**  | <code>string</code> | 7.1.0 |
 | **`email`** | <code>string</code> | 7.1.0 |
+
 
 #### ModifyEventOptions
 
@@ -1177,12 +1226,14 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`title`**        | <code>string</code>                                                 |                                                                                                                                                        |                                   | 0.4.0 | Android, iOS |
 | **`url`**          | <code>string</code>                                                 |                                                                                                                                                        |                                   | 0.1.0 | iOS          |
 
+
 #### DeleteEventsByIdResult
 
 | Prop          | Type                  | Since |
 | ------------- | --------------------- | ----- |
 | **`deleted`** | <code>string[]</code> | 7.1.0 |
 | **`failed`**  | <code>string[]</code> | 7.1.0 |
+
 
 #### DeleteEventsByIdOptions
 
@@ -1192,6 +1243,7 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`ids`**    | <code>string[]</code>                           |                                                                                                                                                                                                                                  |                                   | 7.1.0 |              |
 | **`span`**   | <code><a href="#eventspan">EventSpan</a></code> | How much of a recurring series to delete. On Android, `THIS_EVENT` cannot target a single recurring occurrence here — use `deleteEvent` with `instanceDate`. Those ids are reported in `failed`.                                 | <code>EventSpan.THIS_EVENT</code> | 7.1.0 | Android, iOS |
 
+
 #### DeleteEventOptions
 
 | Prop               | Type                                            | Description                                                                                                                                                                                                                                              | Default                           | Since | Platform     |
@@ -1200,6 +1252,7 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`id`**           | <code>string</code>                             | The ID of the event to delete.                                                                                                                                                                                                                           |                                   | 7.1.0 | Android, iOS |
 | **`instanceDate`** | <code>number</code>                             | The start time of the occurrence to delete, in milliseconds since the epoch. Use `startDate` from `listEventsInRange`. On Android, required for `THIS_EVENT` on recurring events. If omitted with `THIS_AND_FUTURE_EVENTS`, the whole series is deleted. |                                   | 8.3.0 | Android      |
 | **`span`**         | <code><a href="#eventspan">EventSpan</a></code> | How much of a recurring series to delete.                                                                                                                                                                                                                | <code>EventSpan.THIS_EVENT</code> | 7.1.0 | Android, iOS |
+
 
 #### DeleteEventWithPromptOptions
 
@@ -1214,31 +1267,41 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`span`**              | <code><a href="#eventspan">EventSpan</a></code> | How much of a recurring series to delete.                                                                                                                                                                                                                | <code>EventSpan.THIS_EVENT</code> | 7.1.0 | Android, iOS |
 | **`title`**             | <code>string</code>                             | Title of the dialog.                                                                                                                                                                                                                                     |                                   | 7.1.0 | Android, iOS |
 
+
+#### ListEventsInRangeResult
+
+| Prop         | Type                         | Description                              | Since | Platform     |
+| ------------ | ---------------------------- | ---------------------------------------- | ----- | ------------ |
+| **`result`** | <code>CalendarEvent[]</code> | Events that overlap the requested range. | 8.6.0 | Android, iOS |
+
+
 #### CalendarEvent
 
-| Prop                            | Type                                                                                                                                                                                                                                          | Description                                         | Since | Platform     |
-| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ----- | ------------ |
-| **`id`**                        | <code>string</code>                                                                                                                                                                                                                           |                                                     | 7.1.0 | Android, iOS |
-| **`title`**                     | <code>string</code>                                                                                                                                                                                                                           |                                                     | 7.1.0 | Android, iOS |
-| **`calendarId`**                | <code>string \| null</code>                                                                                                                                                                                                                   |                                                     | 7.1.0 | Android, iOS |
-| **`location`**                  | <code>string \| null</code>                                                                                                                                                                                                                   |                                                     | 7.1.0 | Android, iOS |
-| **`startDate`**                 | <code>number</code>                                                                                                                                                                                                                           |                                                     | 7.1.0 | Android, iOS |
-| **`endDate`**                   | <code>number</code>                                                                                                                                                                                                                           |                                                     | 7.1.0 | Android, iOS |
-| **`isAllDay`**                  | <code>boolean</code>                                                                                                                                                                                                                          |                                                     | 7.1.0 | Android, iOS |
-| **`alerts`**                    | <code>number[]</code>                                                                                                                                                                                                                         | Alert times in minutes relative to the event start. | 7.1.0 | Android, iOS |
-| **`url`**                       | <code>string \| null</code>                                                                                                                                                                                                                   |                                                     | 7.1.0 | iOS          |
-| **`description`**               | <code>string \| null</code>                                                                                                                                                                                                                   |                                                     | 7.1.0 | Android, iOS |
-| **`availability`**              | <code><a href="#eventavailability">EventAvailability</a> \| null</code>                                                                                                                                                                       |                                                     | 7.1.0 | Android, iOS |
-| **`organizer`**                 | <code>string \| null</code>                                                                                                                                                                                                                   |                                                     | 7.1.0 | Android, iOS |
-| **`color`**                     | <code>string \| null</code>                                                                                                                                                                                                                   |                                                     | 7.1.0 | Android, iOS |
-| **`duration`**                  | <code>string \| null</code>                                                                                                                                                                                                                   |                                                     | 7.1.0 | Android      |
-| **`isDetached`**                | <code>boolean \| null</code>                                                                                                                                                                                                                  |                                                     | 7.1.0 | iOS          |
-| **`birthdayContactIdentifier`** | <code>string \| null</code>                                                                                                                                                                                                                   |                                                     | 7.1.0 | iOS          |
-| **`status`**                    | <code><a href="#eventstatus">EventStatus</a> \| null</code>                                                                                                                                                                                   |                                                     | 7.1.0 | Android, iOS |
-| **`creationDate`**              | <code>number \| null</code>                                                                                                                                                                                                                   |                                                     | 7.1.0 | iOS          |
-| **`lastModifiedDate`**          | <code>number \| null</code>                                                                                                                                                                                                                   |                                                     | 7.1.0 | iOS          |
-| **`attendees`**                 | <code>{ email: string \| null; name: string \| null; role: <a href="#attendeerole">AttendeeRole</a> \| null; status: <a href="#attendeestatus">AttendeeStatus</a> \| null; type: <a href="#attendeetype">AttendeeType</a> \| null; }[]</code> |                                                     | 7.1.0 | Android, iOS |
-| **`timezone`**                  | <code>string \| null</code>                                                                                                                                                                                                                   |                                                     | 7.1.0 | Android, iOS |
+| Prop                            | Type                                                                                                                                                                                                                                          | Description                                                                                                                                                                                | Since | Platform     |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- | ------------ |
+| **`id`**                        | <code>string</code>                                                                                                                                                                                                                           |                                                                                                                                                                                            | 7.1.0 | Android, iOS |
+| **`title`**                     | <code>string</code>                                                                                                                                                                                                                           |                                                                                                                                                                                            | 7.1.0 | Android, iOS |
+| **`calendarId`**                | <code>string \| null</code>                                                                                                                                                                                                                   |                                                                                                                                                                                            | 7.1.0 | Android, iOS |
+| **`location`**                  | <code>string \| null</code>                                                                                                                                                                                                                   |                                                                                                                                                                                            | 7.1.0 | Android, iOS |
+| **`startDate`**                 | <code>number</code>                                                                                                                                                                                                                           |                                                                                                                                                                                            | 7.1.0 | Android, iOS |
+| **`endDate`**                   | <code>number</code>                                                                                                                                                                                                                           |                                                                                                                                                                                            | 7.1.0 | Android, iOS |
+| **`isAllDay`**                  | <code>boolean</code>                                                                                                                                                                                                                          |                                                                                                                                                                                            | 7.1.0 | Android, iOS |
+| **`alerts`**                    | <code>number[]</code>                                                                                                                                                                                                                         | Alert times in minutes relative to the event start.                                                                                                                                        | 7.1.0 | Android, iOS |
+| **`url`**                       | <code>string \| null</code>                                                                                                                                                                                                                   |                                                                                                                                                                                            | 7.1.0 | iOS          |
+| **`description`**               | <code>string \| null</code>                                                                                                                                                                                                                   |                                                                                                                                                                                            | 7.1.0 | Android, iOS |
+| **`availability`**              | <code><a href="#eventavailability">EventAvailability</a> \| null</code>                                                                                                                                                                       |                                                                                                                                                                                            | 7.1.0 | Android, iOS |
+| **`organizer`**                 | <code>string \| null</code>                                                                                                                                                                                                                   |                                                                                                                                                                                            | 7.1.0 | Android, iOS |
+| **`color`**                     | <code>string \| null</code>                                                                                                                                                                                                                   |                                                                                                                                                                                            | 7.1.0 | Android, iOS |
+| **`duration`**                  | <code>string \| null</code>                                                                                                                                                                                                                   |                                                                                                                                                                                            | 7.1.0 | Android      |
+| **`isDetached`**                | <code>boolean \| null</code>                                                                                                                                                                                                                  |                                                                                                                                                                                            | 7.1.0 | iOS          |
+| **`isPartOfSeries`**            | <code>boolean</code>                                                                                                                                                                                                                          | Whether this event belongs to a recurring series. `true` for series occurrences and detached exceptions. `false` for one-off events. Detached exceptions also set `isDetached` (iOS only). | 8.6.0 | Android, iOS |
+| **`birthdayContactIdentifier`** | <code>string \| null</code>                                                                                                                                                                                                                   |                                                                                                                                                                                            | 7.1.0 | iOS          |
+| **`status`**                    | <code><a href="#eventstatus">EventStatus</a> \| null</code>                                                                                                                                                                                   |                                                                                                                                                                                            | 7.1.0 | Android, iOS |
+| **`creationDate`**              | <code>number \| null</code>                                                                                                                                                                                                                   |                                                                                                                                                                                            | 7.1.0 | iOS          |
+| **`lastModifiedDate`**          | <code>number \| null</code>                                                                                                                                                                                                                   |                                                                                                                                                                                            | 7.1.0 | iOS          |
+| **`attendees`**                 | <code>{ email: string \| null; name: string \| null; role: <a href="#attendeerole">AttendeeRole</a> \| null; status: <a href="#attendeestatus">AttendeeStatus</a> \| null; type: <a href="#attendeetype">AttendeeType</a> \| null; }[]</code> |                                                                                                                                                                                            | 7.1.0 | Android, iOS |
+| **`timezone`**                  | <code>string \| null</code>                                                                                                                                                                                                                   |                                                                                                                                                                                            | 7.1.0 | Android, iOS |
+
 
 #### ListEventsInRangeOptions
 
@@ -1247,11 +1310,13 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`from`** | <code>number</code> | The start of the range, in milliseconds since the epoch. Events still in progress at this time are included.                                                                            | 7.1.0 |
 | **`to`**   | <code>number</code> | The end of the range, in milliseconds since the epoch. Events that begin at or after this time are typically excluded; prefer the next day's start when querying a single calendar day. | 7.1.0 |
 
+
 #### SelectCalendarsWithPromptResult
 
 | Prop         | Type                    | Description                                                               | Since | Platform |
 | ------------ | ----------------------- | ------------------------------------------------------------------------- | ----- | -------- |
 | **`result`** | <code>Calendar[]</code> | Calendars the user confirmed in the chooser. Empty when the user cancels. | 8.4.0 | iOS      |
+
 
 #### Calendar
 
@@ -1272,6 +1337,7 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`maxReminders`**               | <code>number \| null</code>                                       | Maximum number of reminders allowed per event.                                                                                                                                                 | 7.1.0 | Android      |
 | **`location`**                   | <code>string \| null</code>                                       |                                                                                                                                                                                                | 7.1.0 | Android      |
 
+
 #### CalendarSource
 
 | Prop        | Type                                                              | Since | Platform |
@@ -1280,6 +1346,7 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`id`**    | <code>string</code>                                               | 7.1.0 | iOS      |
 | **`title`** | <code>string</code>                                               | 7.1.0 | iOS      |
 
+
 #### SelectCalendarsWithPromptOptions
 
 | Prop               | Type                                                                                | Description                | Default                                                | Since |
@@ -1287,11 +1354,13 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`displayStyle`** | <code><a href="#calendarchooserdisplaystyle">CalendarChooserDisplayStyle</a></code> |                            | <code>CalendarChooserDisplayStyle.ALL_CALENDARS</code> | 7.1.0 |
 | **`multiple`**     | <code>boolean</code>                                                                | Allow multiple selections. | <code>false</code>                                     | 7.1.0 |
 
+
 #### FetchAllCalendarSourcesResult
 
 | Prop         | Type                          | Description                                        | Since | Platform |
 | ------------ | ----------------------------- | -------------------------------------------------- | ----- | -------- |
 | **`result`** | <code>CalendarSource[]</code> | All calendar sources (accounts) known to EventKit. | 8.4.0 | iOS      |
+
 
 #### ListCalendarsResult
 
@@ -1299,11 +1368,13 @@ Options for {@link CalendarAccess#requestPermission}.
 | ------------ | ----------------------- | ------------------------ | ----- | ------------ |
 | **`result`** | <code>Calendar[]</code> | All available calendars. | 8.4.0 | Android, iOS |
 
+
 #### GetDefaultCalendarOptions
 
 | Prop                      | Type                 | Description                                                                 | Default            | Since | Platform     |
 | ------------------------- | -------------------- | --------------------------------------------------------------------------- | ------------------ | ----- | ------------ |
 | **`useFallbackCalendar`** | <code>boolean</code> | When there is no system default calendar, use the first available calendar. | <code>false</code> | 8.4.0 | Android, iOS |
+
 
 #### OpenCalendarOptions
 
@@ -1311,11 +1382,13 @@ Options for {@link CalendarAccess#requestPermission}.
 | ---------- | ------------------- | ------------------------------------------------------------------ | ----------------------- | ----- | ------------ |
 | **`date`** | <code>number</code> | The date to open the calendar at, in milliseconds since the epoch. | <code>Date.now()</code> | 7.1.0 | Android, iOS |
 
+
 #### CreateCalendarResult
 
 | Prop     | Type                | Description                               | Since | Platform     |
 | -------- | ------------------- | ----------------------------------------- | ----- | ------------ |
 | **`id`** | <code>string</code> | Identifier of the newly created calendar. | 8.4.0 | Android, iOS |
+
 
 #### CreateCalendarOptions
 
@@ -1327,11 +1400,13 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`accountName`**  | <code>string</code> | The account under which the calendar is registered. Required on Android. Typically an email address.                                                                                                                       |                      | 7.1.0 | Android      |
 | **`ownerAccount`** | <code>string</code> | The owner of the calendar. Required on Android. Typically an email address.                                                                                                                                                |                      | 7.1.0 | Android      |
 
+
 #### DeleteCalendarOptions
 
 | Prop     | Type                | Since | Platform     |
 | -------- | ------------------- | ----- | ------------ |
 | **`id`** | <code>string</code> | 7.1.0 | Android, iOS |
+
 
 #### ModifyCalendarOptions
 
@@ -1341,11 +1416,13 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`title`** | <code>string</code> | Display title of the calendar. On Android this updates both `CALENDAR_DISPLAY_NAME` (`title`) and `Calendars.NAME` (`internalTitle`). | 7.2.0 | Android, iOS |
 | **`color`** | <code>string</code> | The color of the calendar as `#RRGGBB` or `#RRGGBBAA`.                                                                                | 7.2.0 | Android, iOS |
 
+
 #### CreateRemindersListResult
 
 | Prop     | Type                | Description                                     | Since | Platform |
 | -------- | ------------------- | ----------------------------------------------- | ----- | -------- |
 | **`id`** | <code>string</code> | Identifier of the newly created reminders list. | 8.1.0 | iOS      |
+
 
 #### CreateRemindersListOptions
 
@@ -1356,12 +1433,14 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`sourceId`** | <code>string</code>                                                                                                              | The EKSource identifier (account) where the list should be created. If left undefined, iCloud will be used if available, otherwise falls back to local.                                                                      |                     | 8.1.0 | iOS      |
 | **`title`**    | <code>string</code>                                                                                                              | The title of the list.                                                                                                                                                                                                       |                     | 8.1.0 | iOS      |
 
+
 #### DeleteRemindersListOptions
 
 | Prop         | Type                 | Description                                                                                                                                                                                                                      | Default           | Since | Platform |
 | ------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | ----- | -------- |
 | **`commit`** | <code>boolean</code> | Whether to save the deletion to the event store immediately. Pass `false` to batch multiple changes and commit them together using `CapacitorCalendar.commit()`, which is more efficient than committing each save individually. | <code>true</code> | 8.2.0 | iOS      |
 | **`id`**     | <code>string</code>  | Identifier of the reminders list to delete.                                                                                                                                                                                      |                   | 8.2.0 | iOS      |
+
 
 #### CreateReminderOptions
 
@@ -1380,6 +1459,7 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`recurrence`**     | <code><a href="#recurrencerule">RecurrenceRule</a></code> |                                                                                                                                                           | 7.1.0 |
 | **`alerts`**         | <code>number[]</code>                                     | Alert times in minutes relative to the reminder start. Use negative numbers for alerts before the start, and positive numbers for alerts after the start. | 7.1.0 |
 
+
 #### RecurrenceRule
 
 | Prop            | Type                                                                | Description                                                                        | Since |
@@ -1388,6 +1468,7 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`interval`**  | <code>number</code>                                                 | How often it repeats (e.g. 1 for every occurrence, 2 for every second occurrence). | 7.1.0 |
 | **`end`**       | <code>number</code>                                                 | Timestamp of when the recurrence ends.                                             | 7.1.0 |
 
+
 #### DeleteRemindersByIdResult
 
 | Prop          | Type                  | Since |
@@ -1395,17 +1476,20 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`deleted`** | <code>string[]</code> | 7.1.0 |
 | **`failed`**  | <code>string[]</code> | 7.1.0 |
 
+
 #### DeleteRemindersByIdOptions
 
 | Prop      | Type                  | Since |
 | --------- | --------------------- | ----- |
 | **`ids`** | <code>string[]</code> | 7.1.0 |
 
+
 #### DeleteReminderOptions
 
 | Prop     | Type                | Since |
 | -------- | ------------------- | ----- |
 | **`id`** | <code>string</code> | 7.1.0 |
+
 
 #### ModifyReminderOptions
 
@@ -1425,6 +1509,7 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`recurrence`**     | <code><a href="#recurrencerule">RecurrenceRule</a></code> |                                                                                                                                                                                               | 7.1.0 |
 | **`alerts`**         | <code>number[]</code>                                     | Alert times in minutes relative to the reminder start. Use negative numbers for alerts before the start, and positive numbers for alerts after the start. On iOS only 2 alerts are supported. | 7.1.0 |
 
+
 #### Reminder
 
 | Prop                 | Type                          | Since |
@@ -1443,17 +1528,20 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`recurrence`**     | <code>RecurrenceRule[]</code> | 7.1.0 |
 | **`alerts`**         | <code>number[]</code>         | 7.1.0 |
 
+
 #### GetReminderByIdOptions
 
 | Prop     | Type                | Since |
 | -------- | ------------------- | ----- |
 | **`id`** | <code>string</code> | 7.1.0 |
 
+
 #### GetRemindersFromListsOptions
 
 | Prop          | Type                  | Since |
 | ------------- | --------------------- | ----- |
 | **`listIds`** | <code>string[]</code> | 7.1.0 |
+
 
 #### DeleteReminderWithPromptOptions
 
@@ -1465,11 +1553,13 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`confirmButtonText`** | <code>string</code> | Text to show on the confirm button. | <code>'Delete'</code> | 7.2.0 |
 | **`cancelButtonText`**  | <code>string</code> | Text to show on the cancel button.  | <code>'Cancel'</code> | 7.2.0 |
 
+
 #### UpdateRemindersListResult
 
 | Prop     | Type                | Description                               | Since | Platform |
 | -------- | ------------------- | ----------------------------------------- | ----- | -------- |
 | **`id`** | <code>string</code> | Identifier of the updated reminders list. | 8.2.0 | iOS      |
+
 
 #### UpdateRemindersListOptions
 
@@ -1480,48 +1570,49 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`id`**     | <code>string</code>                                                                                                              | The identifier of the list to update.                                                                                                                                                                                   |                   | 8.2.0 | iOS      |
 | **`title`**  | <code>string</code>                                                                                                              | The new title of the list. If omitted, the title is left unchanged.                                                                                                                                                     |                   | 8.2.0 | iOS      |
 
+
 ### Type Aliases
+
 
 #### PermissionState
 
 <code>'prompt' | 'prompt-with-rationale' | 'granted' | 'denied'</code>
 
+
 #### CheckAllPermissionsResult
 
-<code>
-  <a href="#record">Record</a>&lt;<a href="#calendarpermissionscope">CalendarPermissionScope</a>,{' '}
-  <a href="#permissionstate">PermissionState</a>&gt;
-</code>
+<code><a href="#record">Record</a>&lt;<a href="#calendarpermissionscope">CalendarPermissionScope</a>, <a href="#permissionstate">PermissionState</a>&gt;</code>
+
 
 #### Record
 
 Construct a type with a set of properties K of type T
 
-<code>{
- [P in K]: T;
- }</code>
+<code>{ [P in K]: T; }</code>
+
 
 #### RequestAllPermissionsResult
 
-<code>
-  <a href="#checkallpermissionsresult">CheckAllPermissionsResult</a>
-</code>
+<code><a href="#checkallpermissionsresult">CheckAllPermissionsResult</a></code>
+
 
 #### RecurrenceFrequency
 
 <code>'daily' | 'weekly' | 'monthly' | 'yearly'</code>
 
+
 #### EventEditAction
 
 <code>'canceled' | 'saved' | 'deleted'</code>
 
+
 #### RemindersList
 
-<code>
-  <a href="#calendar">Calendar</a>
-</code>
+<code><a href="#calendar">Calendar</a></code>
+
 
 ### Enums
+
 
 #### CalendarPermissionScope
 
@@ -1531,6 +1622,7 @@ Construct a type with a set of properties K of type T
 | **`READ_REMINDERS`**  | <code>'readReminders'</code>  | Permission required for reading reminders. On Android, reminders are not supported. `checkPermission` and `checkAllPermissions` return `"prompt"` for this scope. `requestPermission` rejects with `Invalid scope.`.             | 7.1.0 | iOS          |
 | **`WRITE_CALENDAR`**  | <code>'writeCalendar'</code>  | Permission required for adding or modifying calendar events.                                                                                                                                                                     | 7.1.0 | Android, iOS |
 | **`WRITE_REMINDERS`** | <code>'writeReminders'</code> | Permission required for adding or modifying reminders. On Android, reminders are not supported. `checkPermission` and `checkAllPermissions` return `"prompt"` for this scope. `requestPermission` rejects with `Invalid scope.`. | 7.1.0 | iOS          |
+
 
 #### EventAvailability
 
@@ -1542,12 +1634,14 @@ Construct a type with a set of properties K of type T
 | **`TENTATIVE`**     |                 | 7.1.0 | Android, iOS |
 | **`UNAVAILABLE`**   |                 | 7.1.0 | iOS          |
 
+
 #### EventSpan
 
 | Members                      | Description                                                     | Since |
 | ---------------------------- | --------------------------------------------------------------- | ----- |
 | **`THIS_EVENT`**             | Only the identified event or occurrence.                        | 7.1.0 |
 | **`THIS_AND_FUTURE_EVENTS`** | The identified occurrence and future occurrences in the series. | 7.1.0 |
+
 
 #### EventStatus
 
@@ -1557,6 +1651,7 @@ Construct a type with a set of properties K of type T
 | **`CONFIRMED`** | <code>'confirmed'</code> | 7.1.0 | Android, iOS |
 | **`TENTATIVE`** | <code>'tentative'</code> | 7.1.0 | Android, iOS |
 | **`CANCELED`**  | <code>'canceled'</code>  | 7.1.0 | Android, iOS |
+
 
 #### AttendeeRole
 
@@ -1571,6 +1666,7 @@ Construct a type with a set of properties K of type T
 | **`ORGANIZER`**       | <code>'organizer'</code>      | 7.1.0 | Android      |
 | **`PERFORMER`**       | <code>'performer'</code>      | 7.1.0 | Android      |
 | **`SPEAKER`**         | <code>'speaker'</code>        | 7.1.0 | Android      |
+
 
 #### AttendeeStatus
 
@@ -1587,6 +1683,7 @@ Construct a type with a set of properties K of type T
 | **`COMPLETED`**  | <code>'completed'</code> | 7.1.0 | iOS          |
 | **`IN_PROCESS`** | <code>'inProcess'</code> | 7.1.0 | iOS          |
 
+
 #### AttendeeType
 
 | Members        | Value                   | Since | Platform     |
@@ -1600,6 +1697,7 @@ Construct a type with a set of properties K of type T
 | **`NONE`**     | <code>'none'</code>     | 7.1.0 | Android      |
 | **`OPTIONAL`** | <code>'optional'</code> | 7.1.0 | Android      |
 
+
 #### CalendarType
 
 | Members            | Since |
@@ -1609,6 +1707,7 @@ Construct a type with a set of properties K of type T
 | **`EXCHANGE`**     | 7.1.0 |
 | **`SUBSCRIPTION`** | 7.1.0 |
 | **`BIRTHDAY`**     | 7.1.0 |
+
 
 #### CalendarSourceType
 
@@ -1620,6 +1719,7 @@ Construct a type with a set of properties K of type T
 | **`MOBILE_ME`**  | 7.1.0 |
 | **`SUBSCRIBED`** | 7.1.0 |
 | **`BIRTHDAYS`**  | 7.1.0 |
+
 
 #### CalendarChooserDisplayStyle
 

--- a/android/src/main/java/dev/barooni/capacitor/calendar/implementation/CapacitorCalendar.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/implementation/CapacitorCalendar.kt
@@ -331,6 +331,8 @@ class CapacitorCalendar(
                 CalendarContract.Instances.EVENT_TIMEZONE,
                 CalendarContract.Instances.STATUS,
                 CalendarContract.Instances.DURATION,
+                CalendarContract.Instances.RRULE,
+                CalendarContract.Instances.ORIGINAL_ID,
             )
 
         val selection =
@@ -409,6 +411,18 @@ class CapacitorCalendar(
 
                 val attendees = ImplementationHelper.getEventAttendees(cr, eventId)
 
+                val rrule =
+                    cursorInstance
+                        .getColumnIndex(CalendarContract.Instances.RRULE)
+                        .takeIf { it != -1 }
+                        ?.let { cursorInstance.getString(it) }
+
+                val originalIdIndex = cursorInstance.getColumnIndex(CalendarContract.Instances.ORIGINAL_ID)
+                val hasOriginalId =
+                    originalIdIndex != -1 && !cursorInstance.isNull(originalIdIndex)
+
+                val isPartOfSeries = !rrule.isNullOrEmpty() || hasOriginalId
+
                 events.add(
                     CalendarEvent(
                         eventId.toString(),
@@ -426,6 +440,7 @@ class CapacitorCalendar(
                         color,
                         duration,
                         null,
+                        isPartOfSeries,
                         null,
                         status,
                         null,

--- a/android/src/main/java/dev/barooni/capacitor/calendar/models/data/CalendarEvent.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/models/data/CalendarEvent.kt
@@ -16,6 +16,7 @@ data class CalendarEvent(
     val color: String?,
     val duration: String?,
     val isDetached: Boolean?,
+    val isPartOfSeries: Boolean,
     val birthdayContactIdentifier: String?,
     val status: String?,
     val creationDate: Long?,

--- a/android/src/main/java/dev/barooni/capacitor/calendar/models/results/CreateEventResult.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/models/results/CreateEventResult.kt
@@ -15,6 +15,7 @@ data class CreateEventResult(
 
     override fun toJSON(): JSObject {
         val result = JSObject()
+        result.put("ics", null)
         result.put("id", id.toString())
         return result
     }

--- a/android/src/main/java/dev/barooni/capacitor/calendar/models/results/ListEventsInRangeResult.kt
+++ b/android/src/main/java/dev/barooni/capacitor/calendar/models/results/ListEventsInRangeResult.kt
@@ -32,6 +32,7 @@ data class ListEventsInRangeResult(
             obj.put("color", event.color)
             obj.put("duration", event.duration)
             obj.put("isDetached", event.isDetached)
+            obj.put("isPartOfSeries", event.isPartOfSeries)
             obj.put("birthdayContactIdentifier", event.birthdayContactIdentifier)
             obj.put("status", event.status)
             obj.put("creationDate", event.creationDate)

--- a/example-app/package-lock.json
+++ b/example-app/package-lock.json
@@ -20,7 +20,7 @@
     },
     "..": {
       "name": "@ebarooni/capacitor-calendar",
-      "version": "8.5.0",
+      "version": "8.6.0",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^8.0.0",

--- a/ios/Plugin/Models/Results/CreateEventResult.swift
+++ b/ios/Plugin/Models/Results/CreateEventResult.swift
@@ -12,6 +12,7 @@ struct CreateEventResult: JSResult {
 
     func toJSON() -> JSObject {
         var result = JSObject()
+        result["ics"] = NSNull()
         result["id"] = id
         return result
     }

--- a/ios/Plugin/Utils/ImplementationHelper.swift
+++ b/ios/Plugin/Utils/ImplementationHelper.swift
@@ -280,6 +280,7 @@ struct ImplementationHelper {
             "color": ImplementationHelper.cgColorToHex(event.calendar.cgColor) ?? NSNull(),
             "duration": NSNull(),
             "isDetached": event.isDetached,
+            "isPartOfSeries": event.hasRecurrenceRules || event.isDetached,
             "birthdayContactIdentifier": event.birthdayContactIdentifier ?? NSNull(),
             "status": ImplementationHelper.mapEKEventStatusToEventStatus(event.status),
             "attendees": []

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebarooni/capacitor-calendar",
-  "version": "8.5.0",
+  "version": "8.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebarooni/capacitor-calendar",
-      "version": "8.5.0",
+      "version": "8.6.0",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebarooni/capacitor-calendar",
-  "version": "8.5.0",
+  "version": "8.6.0",
   "description": "A Capacitor plugin for managing calendar events on iOS, Android, and the web, with reminders support on iOS.",
   "author": "Ehsan Barooni",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "build": "npm run clean && npm run docgen && tsc && rollup -c rollup.config.mjs",
     "build:app": "cd example-app && npm run build",
     "clean": "rimraf ./dist",
-    "docgen": "docgen --api CapacitorCalendarPlugin --output-readme README.md --output-json dist/docs.json",
+    "docgen": "docgen --api CapacitorCalendarPlugin --output-readme README.md --output-json dist/docs.json && prettier --write README.md",
     "eslint": "eslint . --ext ts",
     "fmt": "npm run eslint -- --fix && npm run prettier:fix && npm run swiftlint -- --fix --format && npm run fmt:android",
     "fmt:android": "npm run ktlint -- -F",

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import type { GetReminderByIdOptions } from './schemas/interfaces/get-reminder-b
 import type { GetRemindersFromListsOptions } from './schemas/interfaces/get-reminders-from-lists-options';
 import type { ListCalendarsResult } from './schemas/interfaces/list-calendars-result';
 import type { ListEventsInRangeOptions } from './schemas/interfaces/list-events-in-range-options';
+import type { ListEventsInRangeResult } from './schemas/interfaces/list-events-in-range-result';
 import type { ModifyCalendarOptions } from './schemas/interfaces/modify-calendar-options';
 import type { ModifyEventOptions } from './schemas/interfaces/modify-event-options';
 import type { ModifyEventWithPromptOptions } from './schemas/interfaces/modify-event-with-prompt-options';
@@ -99,6 +100,7 @@ export type {
   GetRemindersFromListsOptions,
   ListCalendarsResult,
   ListEventsInRangeOptions,
+  ListEventsInRangeResult,
   ModifyCalendarOptions,
   ModifyEventOptions,
   ModifyEventWithPromptOptions,

--- a/src/schemas/interfaces/calendar-event.ts
+++ b/src/schemas/interfaces/calendar-event.ts
@@ -86,6 +86,19 @@ export interface CalendarEvent {
    */
   isDetached: boolean | null;
   /**
+   * Whether this event belongs to a recurring series.
+   *
+   * `true` for series occurrences and detached exceptions.
+   * `false` for one-off events.
+   *
+   * Detached exceptions also set `isDetached` (iOS only).
+   *
+   * @example true
+   * @platform Android, iOS
+   * @since 8.6.0
+   */
+  isPartOfSeries: boolean;
+  /**
    * @platform iOS
    * @see {@link https://developer.apple.com/documentation/eventkit/ekevent/birthdaycontactidentifier}
    * @since 7.1.0

--- a/src/schemas/interfaces/create-event-result.ts
+++ b/src/schemas/interfaces/create-event-result.ts
@@ -4,13 +4,14 @@
 export interface CreateEventResult {
   /**
    * An `.ics` file (`text/calendar`) with one `VEVENT`.
-   * Present only on Web. The plugin does not write to a calendar store or start a download;
+   * Always `null` on Android and iOS.
+   * On Web, the plugin does not write to a calendar store or start a download;
    * use `downloadIcsFile(...)` or pass the `File` to another API.
    *
    * @platform Web
    * @since 8.5.0
    */
-  ics?: File;
+  ics: File | null;
   /**
    * The identifier of the created event.
    * Always `null` on Web.

--- a/src/schemas/interfaces/list-events-in-range-result.ts
+++ b/src/schemas/interfaces/list-events-in-range-result.ts
@@ -1,0 +1,14 @@
+import type { CalendarEvent } from './calendar-event';
+
+/**
+ * @since 8.6.0
+ */
+export interface ListEventsInRangeResult {
+  /**
+   * Events that overlap the requested range.
+   *
+   * @platform Android, iOS
+   * @since 8.6.0
+   */
+  result: CalendarEvent[];
+}

--- a/src/sub-definitions/event-operations.ts
+++ b/src/sub-definitions/event-operations.ts
@@ -1,4 +1,3 @@
-import type { CalendarEvent } from '../schemas/interfaces/calendar-event';
 import type { CreateEventOptions } from '../schemas/interfaces/create-event-options';
 import type { CreateEventResult } from '../schemas/interfaces/create-event-result';
 import type { CreateEventWithPromptOptions } from '../schemas/interfaces/create-event-with-prompt-options';
@@ -7,6 +6,7 @@ import type { DeleteEventOptions } from '../schemas/interfaces/delete-event-opti
 import type { DeleteEventWithPromptOptions } from '../schemas/interfaces/delete-event-with-prompt-options';
 import type { DeleteEventsByIdOptions } from '../schemas/interfaces/delete-events-by-id-options';
 import type { ListEventsInRangeOptions } from '../schemas/interfaces/list-events-in-range-options';
+import type { ListEventsInRangeResult } from '../schemas/interfaces/list-events-in-range-result';
 import type { ModifyEventOptions } from '../schemas/interfaces/modify-event-options';
 import type { ModifyEventWithPromptOptions } from '../schemas/interfaces/modify-event-with-prompt-options';
 import type { EventEditAction } from '../schemas/types/event-edit-action';
@@ -113,7 +113,7 @@ export interface EventOperations {
    * @platform Android, iOS
    * @since 0.10.0
    */
-  listEventsInRange(options: ListEventsInRangeOptions): Promise<{ result: CalendarEvent[] }>;
+  listEventsInRange(options: ListEventsInRangeOptions): Promise<ListEventsInRangeResult>;
 }
 
 /**

--- a/src/web.ts
+++ b/src/web.ts
@@ -3,7 +3,6 @@ import { WebPlugin } from '@capacitor/core';
 
 import type { CapacitorCalendarPlugin } from './definitions';
 import type { Calendar } from './schemas/interfaces/calendar';
-import type { CalendarEvent } from './schemas/interfaces/calendar-event';
 import type { CalendarSource } from './schemas/interfaces/calendar-source';
 import type { CheckPermissionOptions } from './schemas/interfaces/check-permission-options';
 import type { CreateCalendarOptions } from './schemas/interfaces/create-calendar-options';
@@ -29,6 +28,7 @@ import type { GetReminderByIdOptions } from './schemas/interfaces/get-reminder-b
 import type { GetRemindersFromListsOptions } from './schemas/interfaces/get-reminders-from-lists-options';
 import type { ListCalendarsResult } from './schemas/interfaces/list-calendars-result';
 import type { ListEventsInRangeOptions } from './schemas/interfaces/list-events-in-range-options';
+import type { ListEventsInRangeResult } from './schemas/interfaces/list-events-in-range-result';
 import type { ModifyCalendarOptions } from './schemas/interfaces/modify-calendar-options';
 import type { ModifyEventOptions } from './schemas/interfaces/modify-event-options';
 import type { ModifyEventWithPromptOptions } from './schemas/interfaces/modify-event-with-prompt-options';
@@ -205,7 +205,7 @@ export class CapacitorCalendarWeb extends WebPlugin implements CapacitorCalendar
     return this.throwUnimplemented(this.deleteEventWithPrompt.name);
   }
 
-  public listEventsInRange(_options: ListEventsInRangeOptions): Promise<{ result: CalendarEvent[] }> {
+  public listEventsInRange(_options: ListEventsInRangeOptions): Promise<ListEventsInRangeResult> {
     return this.throwUnimplemented(this.listEventsInRange.name);
   }
 


### PR DESCRIPTION
## Summary
- Add `CalendarEvent.isPartOfSeries` so apps can tell whether a listed event belongs to a recurring series (Android, iOS).
- Introduce named `ListEventsInRangeResult` for `listEventsInRange(...)` (same JSON shape; non-breaking).
- Always return `CreateEventResult.ics` as `null` on Android and iOS (was omitted / `undefined`).
- Tighten `AGENTS.md` writing-style guidance for public API JSDoc.

Closes: #265

## Test plan
- [ ] On Android and iOS, list a range that includes a one-off event and a recurring series occurrence; confirm `isPartOfSeries` is `false` / `true` respectively.
- [ ] On iOS, confirm a detached exception has `isPartOfSeries: true` and `isDetached: true`.
- [ ] Call `createEvent` on Android and iOS; confirm the result includes `ics: null` (not missing).
- [ ] Confirm TypeScript consumers can use `ListEventsInRangeResult` and that existing `const { result } = await listEventsInRange(...)` still type-checks.