### PR TITLE
docs: clarify web partial support wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Full-featured Capacitor plugin for calendar and reminders access on iOS, Android
 
 - **iOS** — Full support (including Reminders and advanced features)
 - **Android** — Strong support for all core calendar features
-- **Web** — Partial support (create event)
+- **Web** — Partial support (create events as `.ics` files)
 
 ## Why this plugin?
 


### PR DESCRIPTION
## Summary
- Reword the Web platform line in the README from "create event" to "create events as `.ics` files" so partial support is clearer for developers.

## Test plan
- [ ] Confirm the Supported Platforms section reads clearly in the rendered README