### PR TITLE
fix(ios)!: honor reminder recurrence end and string frequency

### DIFF
--- a/.agents/skills/generate-commit-message/SKILL.md
+++ b/.agents/skills/generate-commit-message/SKILL.md
@@ -1,14 +1,24 @@
 ---
 name: generate-commit-message
 description: >
-  Use when generating commit messages or reviewing staged changes.
-  Handles conventional commits format, scope detection, and breaking change notation.
-disable-model-invocation: true
+  Use before any git commit, including when updating a PR, pushing branch
+  work, or when the user asks to commit / commit-and-push. Drafts conventional
+  commit messages, proposes splits when staged changes are not cohesive, and
+  waits for confirmation before running git commit.
 metadata:
-  version: '1.0'
+  version: '1.1'
 ---
 
 # Generate Commit Message
+
+## Triggers
+
+Use this skill whenever any of these apply:
+
+- The user asks to commit, commit and push, or land changes
+- Updating a PR requires new commits on the branch
+- Pushing work that is not yet committed
+- Reviewing or drafting messages for staged changes
 
 ## Workflow
 
@@ -16,7 +26,8 @@ metadata:
 2. Identify the commit type:
    - Normal commit: [`references/normal-commit.md`](references/normal-commit.md)
    - Revert commit: [`references/revert.md`](references/revert.md)
+3. If staged changes are not cohesive, propose a split (commits, messages, and which files/hunks belong to each) before drafting a single message
 
 ## Rules
 
-- Present the drafted message to the user for confirmation. Do not run `git commit` unless the user explicitly asks you to.
+- Present the drafted message (or proposed split) to the user for confirmation. Do not run `git commit` unless the user explicitly asks you to.

--- a/.agents/skills/generate-commit-message/SKILL.md
+++ b/.agents/skills/generate-commit-message/SKILL.md
@@ -11,15 +11,6 @@ metadata:
 
 # Generate Commit Message
 
-## Triggers
-
-Use this skill whenever any of these apply:
-
-- The user asks to commit, commit and push, or land changes
-- Updating a PR requires new commits on the branch
-- Pushing work that is not yet committed
-- Reviewing or drafting messages for staged changes
-
 ## Workflow
 
 1. Run `git diff --cached`. If empty, ask the user to stage changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ This file provides instructions for AI coding agents working on the `ebarooni/ca
 
 - Ensure `projectDocuments` in `typedoc.json` doesn't list files that are deleted or not referenced in `README.md`.
 - When bumping the MCP server version, update the image tag in `mcp/README.md` and `README.md` to match.
+- When a release includes a breaking change, document it in `BREAKING.md` under that version: what changed, before/after if helpful, and migration steps. Link new versions from the Contents list. Keep `CHANGELOG.md` for the concise release summary and point to `BREAKING.md` for migration detail.
 
 ## Tool Preference
 
@@ -41,6 +42,8 @@ When multiple tools can perform the same task, use them in this order:
 - `example-app/`: Local test/demo application
 - `mcp/`: MCP server
 - `assets/`: Images and GIFs
+- `CHANGELOG.md`: Release history
+- `BREAKING.md`: Breaking changes by version, with migration steps
 
 ## Architecture
 
@@ -114,6 +117,7 @@ The title should be formatted as `<type>(<scope>): <description>`
   - The scope can be omitted if multiple scopes apply
 - Append `!` to the type or scope when the PR introduces a breaking change.
   - Examples: `feat!: <description>` or `feat(android)!: <description>`
+  - Update `BREAKING.md` for that release (see Important Rules).
 
 The body should reference the issue the PR closes: `Closes: #<ISSUE_NUMBER>`
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,0 +1,60 @@
+# Breaking Changes
+
+Breaking changes by release, with migration steps.
+See [CHANGELOG.md](CHANGELOG.md) for the full release history.
+
+## Contents
+
+- [Version 8.x.x](#version-8xx)
+  - [8.7.0](#870)
+
+# Version 8.x.x
+
+## 8.7.0
+
+### Reminder recurrence `frequency` is a string
+
+On iOS, reminder recurrence frequency used EventKit integer raw values (`0`–`3`) in these places:
+
+- `modifyReminder(...)` input
+- `getReminderById(...)` / `getRemindersFromLists(...)` read-back
+
+The public TypeScript contract already used string `RecurrenceFrequency` (`'daily' | 'weekly' | 'monthly' | 'yearly'`). Create had been migrated earlier; modify and read-back now match.
+
+#### Before
+
+```ts
+await CapacitorCalendar.modifyReminder({
+  id,
+  recurrence: {
+    frequency: 1, // or ReminderRecurrenceFrequency.WEEKLY
+    interval: 1,
+  },
+});
+
+const { result } = await CapacitorCalendar.getReminderById({ id });
+result?.recurrence[0]?.frequency; // 0 | 1 | 2 | 3
+```
+
+#### After
+
+```ts
+await CapacitorCalendar.modifyReminder({
+  id,
+  recurrence: {
+    frequency: 'weekly',
+    interval: 1,
+  },
+});
+
+const { result } = await CapacitorCalendar.getReminderById({ id });
+result?.recurrence[0]?.frequency; // 'daily' | 'weekly' | 'monthly' | 'yearly'
+```
+
+#### Migration
+
+1. Replace numeric frequencies and `ReminderRecurrenceFrequency.*` with string literals (`'daily'`, `'weekly'`, `'monthly'`, `'yearly'`).
+2. Update any read-back checks that compared frequency to `0`–`3` or to `ReminderRecurrenceFrequency` enum members.
+3. Prefer `RecurrenceRule` / `RecurrenceFrequency`. `ReminderRecurrenceFrequency` and `ReminderRecurrenceRule` remain deprecated.
+
+Passing a non-string frequency (for example `0`) now rejects with `Invalid frequency.`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Contents
 
 - [Version 8.x.x](#version-8xx)
+  - [8.7.0](#870)
   - [8.6.0](#860)
   - [8.5.0](#850)
   - [8.4.0](#840)
@@ -45,6 +46,25 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 # Version 8.x.x
 
 Changelogs for the versions supporting Capacitor 8.
+
+## 8.7.0
+
+### Added
+
+- `CreateReminderResult` for `createReminder(...)`
+- `GetReminderByIdResult` for `getReminderById(...)`
+- `GetRemindersFromListsResult` for `getRemindersFromLists(...)`
+
+### Changed
+
+- iOS reminder recurrence uses string `RecurrenceFrequency` on create, modify, and read (see [BREAKING.md](BREAKING.md#870))
+
+### Fixed
+
+- iOS `createReminder` / `modifyReminder` now apply `recurrence.end`
+- iOS `createReminder` / `modifyReminder` reject invalid or non-string `frequency` with `Invalid frequency.`
+- iOS reminder and event recurrence parsing accepts JS numbers whether bridged as `Int` or `Double` (`interval`, `end`, and related fields)
+- Deprecated `ReminderRecurrenceFrequency` docs now point at string values (`'daily'`, …) instead of `RecurrenceFrequency.DAILY`
 
 ## 8.6.0
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ See [`mcp/README.md`](mcp/README.md) for client configuration and full details.
 - [Usage Examples](#usage-examples)
 - [Documentation](#documentation)
 - [Changelog](#changelog)
+- [Breaking Changes](#breaking-changes)
 - [API](#api)
 - [Contributing](#contributing)
 - [License](#license)
@@ -243,6 +244,10 @@ The full documentation is generated from TypeScript definitions and is available
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md) for the latest updates and release history.
+
+## Breaking Changes
+
+See [BREAKING.md](BREAKING.md) for breaking changes and migration steps.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -893,7 +893,7 @@ Retrieves all available reminders lists.
 ### createReminder(...)
 
 ```typescript
-createReminder(options: CreateReminderOptions) => Promise<{ id: string; }>
+createReminder(options: CreateReminderOptions) => Promise<CreateReminderResult>
 ```
 
 Creates a reminder.
@@ -902,7 +902,7 @@ Creates a reminder.
 | ------------- | ----------------------------------------------------------------------- |
 | **`options`** | <code><a href="#createreminderoptions">CreateReminderOptions</a></code> |
 
-**Returns:** <code>Promise&lt;{ id: string; }&gt;</code>
+**Returns:** <code>Promise&lt;<a href="#createreminderresult">CreateReminderResult</a>&gt;</code>
 
 **Since:** 0.5.0
 
@@ -969,7 +969,7 @@ Modifies a reminder.
 ### getReminderById(...)
 
 ```typescript
-getReminderById(options: GetReminderByIdOptions) => Promise<{ result: Reminder | null; }>
+getReminderById(options: GetReminderByIdOptions) => Promise<GetReminderByIdResult>
 ```
 
 Retrieve a reminder by ID.
@@ -978,7 +978,7 @@ Retrieve a reminder by ID.
 | ------------- | ------------------------------------------------------------------------- |
 | **`options`** | <code><a href="#getreminderbyidoptions">GetReminderByIdOptions</a></code> |
 
-**Returns:** <code>Promise&lt;{ result: <a href="#reminder">Reminder</a> | null; }&gt;</code>
+**Returns:** <code>Promise&lt;<a href="#getreminderbyidresult">GetReminderByIdResult</a>&gt;</code>
 
 **Since:** 7.1.0
 
@@ -989,7 +989,7 @@ Retrieve a reminder by ID.
 ### getRemindersFromLists(...)
 
 ```typescript
-getRemindersFromLists(options: GetRemindersFromListsOptions) => Promise<{ result: Reminder[]; }>
+getRemindersFromLists(options: GetRemindersFromListsOptions) => Promise<GetRemindersFromListsResult>
 ```
 
 Retrieves reminders from multiple lists.
@@ -998,7 +998,7 @@ Retrieves reminders from multiple lists.
 | ------------- | ------------------------------------------------------------------------------------- |
 | **`options`** | <code><a href="#getremindersfromlistsoptions">GetRemindersFromListsOptions</a></code> |
 
-**Returns:** <code>Promise&lt;{ result: Reminder[]; }&gt;</code>
+**Returns:** <code>Promise&lt;<a href="#getremindersfromlistsresult">GetRemindersFromListsResult</a>&gt;</code>
 
 **Since:** 5.3.0
 
@@ -1373,30 +1373,36 @@ Options for {@link CalendarAccess#requestPermission}.
 | **`commit`** | <code>boolean</code> | Whether to save the deletion to the event store immediately. Pass `false` to batch multiple changes and commit them together using `CapacitorCalendar.commit()`, which is more efficient than committing each save individually. | <code>true</code> | 8.2.0 | iOS      |
 | **`id`**     | <code>string</code>  | Identifier of the reminders list to delete.                                                                                                                                                                                      |                   | 8.2.0 | iOS      |
 
+#### CreateReminderResult
+
+| Prop     | Type                | Description                               | Since | Platform |
+| -------- | ------------------- | ----------------------------------------- | ----- | -------- |
+| **`id`** | <code>string</code> | Identifier of the newly created reminder. | 0.5.0 | iOS      |
+
 #### CreateReminderOptions
 
-| Prop                 | Type                                                      | Description                                                                                                                                               | Since |
-| -------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| **`title`**          | <code>string</code>                                       |                                                                                                                                                           | 7.1.0 |
-| **`listId`**         | <code>string</code>                                       |                                                                                                                                                           | 7.1.0 |
-| **`priority`**       | <code>number</code>                                       |                                                                                                                                                           | 7.1.0 |
-| **`isCompleted`**    | <code>boolean</code>                                      |                                                                                                                                                           | 7.1.0 |
-| **`startDate`**      | <code>number</code>                                       |                                                                                                                                                           | 7.1.0 |
-| **`dueDate`**        | <code>number</code>                                       |                                                                                                                                                           | 7.1.0 |
-| **`completionDate`** | <code>number</code>                                       |                                                                                                                                                           | 7.1.0 |
-| **`notes`**          | <code>string</code>                                       |                                                                                                                                                           | 7.1.0 |
-| **`url`**            | <code>string</code>                                       |                                                                                                                                                           | 7.1.0 |
-| **`location`**       | <code>string</code>                                       |                                                                                                                                                           | 7.1.0 |
-| **`recurrence`**     | <code><a href="#recurrencerule">RecurrenceRule</a></code> |                                                                                                                                                           | 7.1.0 |
-| **`alerts`**         | <code>number[]</code>                                     | Alert times in minutes relative to the reminder start. Use negative numbers for alerts before the start, and positive numbers for alerts after the start. | 7.1.0 |
+| Prop                 | Type                                                      | Description                                                                                                                                               | Since | Platform |
+| -------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | -------- |
+| **`title`**          | <code>string</code>                                       |                                                                                                                                                           | 7.1.0 |          |
+| **`listId`**         | <code>string</code>                                       |                                                                                                                                                           | 7.1.0 |          |
+| **`priority`**       | <code>number</code>                                       |                                                                                                                                                           | 7.1.0 |          |
+| **`isCompleted`**    | <code>boolean</code>                                      |                                                                                                                                                           | 7.1.0 |          |
+| **`startDate`**      | <code>number</code>                                       |                                                                                                                                                           | 7.1.0 |          |
+| **`dueDate`**        | <code>number</code>                                       |                                                                                                                                                           | 7.1.0 |          |
+| **`completionDate`** | <code>number</code>                                       |                                                                                                                                                           | 7.1.0 |          |
+| **`notes`**          | <code>string</code>                                       |                                                                                                                                                           | 7.1.0 |          |
+| **`url`**            | <code>string</code>                                       |                                                                                                                                                           | 7.1.0 |          |
+| **`location`**       | <code>string</code>                                       |                                                                                                                                                           | 7.1.0 |          |
+| **`recurrence`**     | <code><a href="#recurrencerule">RecurrenceRule</a></code> |                                                                                                                                                           | 7.1.0 | iOS      |
+| **`alerts`**         | <code>number[]</code>                                     | Alert times in minutes relative to the reminder start. Use negative numbers for alerts before the start, and positive numbers for alerts after the start. | 7.1.0 |          |
 
 #### RecurrenceRule
 
-| Prop            | Type                                                                | Description                                                                        | Since |
-| --------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ----- |
-| **`frequency`** | <code><a href="#recurrencefrequency">RecurrenceFrequency</a></code> |                                                                                    | 7.1.0 |
-| **`interval`**  | <code>number</code>                                                 | How often it repeats (e.g. 1 for every occurrence, 2 for every second occurrence). | 7.1.0 |
-| **`end`**       | <code>number</code>                                                 | Timestamp of when the recurrence ends.                                             | 7.1.0 |
+| Prop            | Type                                                                | Description                                                                        | Since | Platform |
+| --------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ----- | -------- |
+| **`frequency`** | <code><a href="#recurrencefrequency">RecurrenceFrequency</a></code> | How often the reminder repeats.                                                    | 7.1.0 | iOS      |
+| **`interval`**  | <code>number</code>                                                 | How often it repeats (e.g. 1 for every occurrence, 2 for every second occurrence). | 7.1.0 | iOS      |
+| **`end`**       | <code>number</code>                                                 | End of the recurrence series as a Unix timestamp in milliseconds.                  | 7.1.0 | iOS      |
 
 #### DeleteRemindersByIdResult
 
@@ -1419,45 +1425,57 @@ Options for {@link CalendarAccess#requestPermission}.
 
 #### ModifyReminderOptions
 
-| Prop                 | Type                                                      | Description                                                                                                                                                                                   | Since |
-| -------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| **`id`**             | <code>string</code>                                       |                                                                                                                                                                                               | 7.1.0 |
-| **`title`**          | <code>string</code>                                       |                                                                                                                                                                                               | 7.1.0 |
-| **`listId`**         | <code>string</code>                                       |                                                                                                                                                                                               | 7.1.0 |
-| **`priority`**       | <code>number</code>                                       |                                                                                                                                                                                               | 7.1.0 |
-| **`isCompleted`**    | <code>boolean</code>                                      |                                                                                                                                                                                               | 7.1.0 |
-| **`startDate`**      | <code>number</code>                                       |                                                                                                                                                                                               | 7.1.0 |
-| **`dueDate`**        | <code>number</code>                                       |                                                                                                                                                                                               | 7.1.0 |
-| **`completionDate`** | <code>number</code>                                       |                                                                                                                                                                                               | 7.1.0 |
-| **`notes`**          | <code>string</code>                                       |                                                                                                                                                                                               | 7.1.0 |
-| **`url`**            | <code>string</code>                                       |                                                                                                                                                                                               | 7.1.0 |
-| **`location`**       | <code>string</code>                                       |                                                                                                                                                                                               | 7.1.0 |
-| **`recurrence`**     | <code><a href="#recurrencerule">RecurrenceRule</a></code> |                                                                                                                                                                                               | 7.1.0 |
-| **`alerts`**         | <code>number[]</code>                                     | Alert times in minutes relative to the reminder start. Use negative numbers for alerts before the start, and positive numbers for alerts after the start. On iOS only 2 alerts are supported. | 7.1.0 |
+| Prop                 | Type                                                      | Description                                                                                                                                                                                   | Since | Platform |
+| -------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | -------- |
+| **`id`**             | <code>string</code>                                       |                                                                                                                                                                                               | 7.1.0 |          |
+| **`title`**          | <code>string</code>                                       |                                                                                                                                                                                               | 7.1.0 |          |
+| **`listId`**         | <code>string</code>                                       |                                                                                                                                                                                               | 7.1.0 |          |
+| **`priority`**       | <code>number</code>                                       |                                                                                                                                                                                               | 7.1.0 |          |
+| **`isCompleted`**    | <code>boolean</code>                                      |                                                                                                                                                                                               | 7.1.0 |          |
+| **`startDate`**      | <code>number</code>                                       |                                                                                                                                                                                               | 7.1.0 |          |
+| **`dueDate`**        | <code>number</code>                                       |                                                                                                                                                                                               | 7.1.0 |          |
+| **`completionDate`** | <code>number</code>                                       |                                                                                                                                                                                               | 7.1.0 |          |
+| **`notes`**          | <code>string</code>                                       |                                                                                                                                                                                               | 7.1.0 |          |
+| **`url`**            | <code>string</code>                                       |                                                                                                                                                                                               | 7.1.0 |          |
+| **`location`**       | <code>string</code>                                       |                                                                                                                                                                                               | 7.1.0 |          |
+| **`recurrence`**     | <code><a href="#recurrencerule">RecurrenceRule</a></code> |                                                                                                                                                                                               | 7.1.0 | iOS      |
+| **`alerts`**         | <code>number[]</code>                                     | Alert times in minutes relative to the reminder start. Use negative numbers for alerts before the start, and positive numbers for alerts after the start. On iOS only 2 alerts are supported. | 7.1.0 |          |
+
+#### GetReminderByIdResult
+
+| Prop         | Type                                                  | Description                                                | Since | Platform |
+| ------------ | ----------------------------------------------------- | ---------------------------------------------------------- | ----- | -------- |
+| **`result`** | <code><a href="#reminder">Reminder</a> \| null</code> | The reminder for the given id, or `null` when none exists. | 7.1.0 | iOS      |
 
 #### Reminder
 
-| Prop                 | Type                          | Since |
-| -------------------- | ----------------------------- | ----- |
-| **`id`**             | <code>string</code>           | 7.1.0 |
-| **`title`**          | <code>string \| null</code>   | 7.1.0 |
-| **`listId`**         | <code>string \| null</code>   | 7.1.0 |
-| **`isCompleted`**    | <code>boolean</code>          | 7.1.0 |
-| **`priority`**       | <code>number \| null</code>   | 7.1.0 |
-| **`notes`**          | <code>string \| null</code>   | 7.1.0 |
-| **`location`**       | <code>string \| null</code>   | 7.1.0 |
-| **`url`**            | <code>string \| null</code>   | 7.1.0 |
-| **`startDate`**      | <code>number \| null</code>   | 7.1.0 |
-| **`dueDate`**        | <code>number \| null</code>   | 7.1.0 |
-| **`completionDate`** | <code>number \| null</code>   | 7.1.0 |
-| **`recurrence`**     | <code>RecurrenceRule[]</code> | 7.1.0 |
-| **`alerts`**         | <code>number[]</code>         | 7.1.0 |
+| Prop                 | Type                          | Since | Platform |
+| -------------------- | ----------------------------- | ----- | -------- |
+| **`id`**             | <code>string</code>           | 7.1.0 |          |
+| **`title`**          | <code>string \| null</code>   | 7.1.0 |          |
+| **`listId`**         | <code>string \| null</code>   | 7.1.0 |          |
+| **`isCompleted`**    | <code>boolean</code>          | 7.1.0 |          |
+| **`priority`**       | <code>number \| null</code>   | 7.1.0 |          |
+| **`notes`**          | <code>string \| null</code>   | 7.1.0 |          |
+| **`location`**       | <code>string \| null</code>   | 7.1.0 |          |
+| **`url`**            | <code>string \| null</code>   | 7.1.0 |          |
+| **`startDate`**      | <code>number \| null</code>   | 7.1.0 |          |
+| **`dueDate`**        | <code>number \| null</code>   | 7.1.0 |          |
+| **`completionDate`** | <code>number \| null</code>   | 7.1.0 |          |
+| **`recurrence`**     | <code>RecurrenceRule[]</code> | 7.1.0 | iOS      |
+| **`alerts`**         | <code>number[]</code>         | 7.1.0 |          |
 
 #### GetReminderByIdOptions
 
 | Prop     | Type                | Since |
 | -------- | ------------------- | ----- |
 | **`id`** | <code>string</code> | 7.1.0 |
+
+#### GetRemindersFromListsResult
+
+| Prop         | Type                    | Description                         | Since | Platform |
+| ------------ | ----------------------- | ----------------------------------- | ----- | -------- |
+| **`result`** | <code>Reminder[]</code> | Reminders from the requested lists. | 5.3.0 | iOS      |
 
 #### GetRemindersFromListsOptions
 

--- a/example-app/package-lock.json
+++ b/example-app/package-lock.json
@@ -20,7 +20,7 @@
     },
     "..": {
       "name": "@ebarooni/capacitor-calendar",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^8.0.0",

--- a/example-app/src/index.html
+++ b/example-app/src/index.html
@@ -106,6 +106,16 @@
         </ion-item>
         <ion-item lines="none" class="ion-no-padding">
           <ion-input
+            id="reminder-id-input"
+            label="Reminder ID"
+            label-placement="stacked"
+            placeholder="73D6F2A1-4B8C-4E9A-9F3D-1C2B5A7E8D90"
+            helper-text="The identifier of the reminder to use"
+          >
+          </ion-input>
+        </ion-item>
+        <ion-item lines="none" class="ion-no-padding">
+          <ion-input
             id="reminders-list-id-input"
             label="Reminders list ID"
             label-placement="stacked"
@@ -133,6 +143,7 @@
           <ion-button id="create-calendar" expand="block">Create calendar</ion-button>
           <ion-button id="create-event" expand="block">Create event</ion-button>
           <ion-button id="create-event-with-prompt" expand="block">Create event with prompt</ion-button>
+          <ion-button id="create-reminder" expand="block">Create reminder</ion-button>
           <ion-button id="create-reminders-list" expand="block">Create reminders list</ion-button>
           <ion-button id="delete-calendar" expand="block">Delete calendar</ion-button>
           <ion-button id="delete-event" expand="block">Delete event</ion-button>
@@ -140,10 +151,13 @@
           <ion-button id="delete-events-by-id" expand="block">Delete events by id</ion-button>
           <ion-button id="delete-reminders-list" expand="block">Delete reminders list</ion-button>
           <ion-button id="get-default-calendar" expand="block">Get default calendar</ion-button>
+          <ion-button id="get-reminder-by-id" expand="block">Get reminder by id</ion-button>
+          <ion-button id="get-reminders-from-lists" expand="block">Get reminders from lists</ion-button>
           <ion-button id="get-reminders-lists" expand="block">Get reminders lists</ion-button>
           <ion-button id="list-calendars" expand="block">List calendars</ion-button>
           <ion-button id="list-events-in-range" expand="block">List events in range</ion-button>
           <ion-button id="modify-calendar" expand="block">Modify calendar</ion-button>
+          <ion-button id="modify-reminder" expand="block">Modify reminder</ion-button>
           <ion-button id="open-calendar" expand="block">Open calendar</ion-button>
           <ion-button id="open-reminders" expand="block">Open reminders</ion-button>
           <ion-button id="request-full-calendar-access" expand="block" fill="outline"

--- a/example-app/src/js/example.js
+++ b/example-app/src/js/example.js
@@ -98,6 +98,30 @@ document.addEventListener('DOMContentLoaded', () => {
     console.log('#createEventWithPrompt', result);
   });
 
+  document.querySelector('#create-reminder').addEventListener('click', async () => {
+    const startDate = Date.now();
+    const dueDate = startDate + 60 * 60 * 1000;
+    const recurrenceEnd = startDate + 14 * 24 * 60 * 60 * 1000;
+    const listId = getRemindersListIdInput().value.trim();
+
+    const result = await CapacitorCalendar.createReminder({
+      alerts: [-60],
+      dueDate,
+      ...(listId ? { listId } : {}),
+      notes: 'Created with @ebarooni/capacitor-calendar',
+      recurrence: {
+        end: recurrenceEnd,
+        frequency: 'weekly',
+        interval: 1,
+      },
+      startDate,
+      title: 'Weekly grocery check',
+    });
+
+    getReminderIdInput().value = result.id;
+    console.log('#createReminder', result);
+  });
+
   document.querySelector('#create-reminders-list').addEventListener('click', async () => {
     const result = await CapacitorCalendar.createRemindersList({
       color: 'orange',
@@ -158,6 +182,28 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  document.querySelector('#get-reminder-by-id').addEventListener('click', async () => {
+    const result = await CapacitorCalendar.getReminderById({
+      id: getReminderIdInput().value,
+    });
+    console.log('#getReminderById', result);
+  });
+
+  document.querySelector('#get-reminders-from-lists').addEventListener('click', async () => {
+    let listIds = [getRemindersListIdInput().value.trim()].filter(Boolean);
+    if (listIds.length === 0) {
+      const { result: lists } = await CapacitorCalendar.getRemindersLists();
+      listIds = lists.map((list) => list.id).filter(Boolean);
+    }
+
+    const result = await CapacitorCalendar.getRemindersFromLists({ listIds });
+    const reminder = result.result[0];
+    if (reminder?.id) {
+      getReminderIdInput().value = reminder.id;
+    }
+    console.log('#getRemindersFromLists', result);
+  });
+
   document.querySelector('#get-reminders-lists').addEventListener('click', async () => {
     const result = await CapacitorCalendar.getRemindersLists();
     console.log('#getRemindersLists', result);
@@ -193,6 +239,22 @@ document.addEventListener('DOMContentLoaded', () => {
       title: 'Updated Plugin Test Calendar',
     });
     console.log('#modifyCalendar');
+  });
+
+  document.querySelector('#modify-reminder').addEventListener('click', async () => {
+    const recurrenceEnd = Date.now() + 7 * 24 * 60 * 60 * 1000;
+
+    await CapacitorCalendar.modifyReminder({
+      id: getReminderIdInput().value,
+      notes: 'Updated with @ebarooni/capacitor-calendar',
+      recurrence: {
+        end: recurrenceEnd,
+        frequency: 'daily',
+        interval: 2,
+      },
+      title: 'Updated weekly grocery check',
+    });
+    console.log('#modifyReminder');
   });
 
   document.querySelector('#open-calendar').addEventListener('click', async () => {
@@ -304,6 +366,10 @@ function getEventInstanceDateInput() {
 function getEventSpan() {
   const value = Number(document.querySelector('#event-span-select').value);
   return value === EventSpan.THIS_AND_FUTURE_EVENTS ? EventSpan.THIS_AND_FUTURE_EVENTS : EventSpan.THIS_EVENT;
+}
+
+function getReminderIdInput() {
+  return document.querySelector('#reminder-id-input');
 }
 
 function getRemindersListIdInput() {

--- a/ios/Plugin/Models/Inputs/CreateEventWithPromptInput.swift
+++ b/ios/Plugin/Models/Inputs/CreateEventWithPromptInput.swift
@@ -112,11 +112,11 @@ struct CreateEventWithPromptInput {
     static func getRecurrence(from call: CAPPluginCall) -> RecurrenceInput? {
         if let recurrenceObject = call.getObject("recurrence") {
             if let frequencyString = recurrenceObject["frequency"] as? String, let frequency = RecurrenceInput.Frequency(rawValue: frequencyString) {
-                let interval = recurrenceObject["interval"] as? Int ?? 1
-                let count = recurrenceObject["count"] as? Int
+                let interval = ImplementationHelper.int(from: recurrenceObject["interval"]) ?? 1
+                let count = ImplementationHelper.int(from: recurrenceObject["count"])
 
                 var endDate: Date?
-                if let endMs = recurrenceObject["end"] as? Double {
+                if let endMs = ImplementationHelper.double(from: recurrenceObject["end"]) {
                     endDate = ImplementationHelper.dateFromTimestamp(endMs)
                 }
 

--- a/ios/Plugin/Models/Inputs/CreateReminderInput.swift
+++ b/ios/Plugin/Models/Inputs/CreateReminderInput.swift
@@ -32,18 +32,19 @@ struct CreateReminderInput {
         self.url = call.getString("url")
         self.location = call.getString("location")
         if let recurrence = call.getObject("recurrence") {
-            guard let frequencyString = recurrence["frequency"] as? String else {
+            guard recurrence["frequency"] != nil else {
                 throw PluginError.missingFrequency
             }
-            guard let frequency = RecurrenceInput.Frequency(rawValue: frequencyString) else {
+            guard let frequencyString = recurrence["frequency"] as? String,
+                  let frequency = RecurrenceInput.Frequency(rawValue: frequencyString) else {
                 throw PluginError.invalidFrequency
             }
             self.frequency = frequency.toEKFrequency()
-            guard let interval = recurrence["interval"] as? Int else {
+            guard let interval = ImplementationHelper.int(from: recurrence["interval"]) else {
                 throw PluginError.missingInterval
             }
             self.interval = interval
-            self.end = recurrence["end"] as? Double
+            self.end = ImplementationHelper.double(from: recurrence["end"])
         }
         self.alerts = call.getArray("alerts") as? [Double]
     }

--- a/ios/Plugin/Models/Inputs/CreateReminderInput.swift
+++ b/ios/Plugin/Models/Inputs/CreateReminderInput.swift
@@ -32,15 +32,18 @@ struct CreateReminderInput {
         self.url = call.getString("url")
         self.location = call.getString("location")
         if let recurrence = call.getObject("recurrence") {
-            guard let frequency = recurrence["frequency"] as? String else {
+            guard let frequencyString = recurrence["frequency"] as? String else {
                 throw PluginError.missingFrequency
             }
-            self.frequency = RecurrenceInput.Frequency(rawValue: frequency)?.toEKFrequency()
+            guard let frequency = RecurrenceInput.Frequency(rawValue: frequencyString) else {
+                throw PluginError.invalidFrequency
+            }
+            self.frequency = frequency.toEKFrequency()
             guard let interval = recurrence["interval"] as? Int else {
                 throw PluginError.missingInterval
             }
             self.interval = interval
-            let end = recurrence["end"] as? Double
+            self.end = recurrence["end"] as? Double
         }
         self.alerts = call.getArray("alerts") as? [Double]
     }

--- a/ios/Plugin/Models/Inputs/ModifyReminderInput.swift
+++ b/ios/Plugin/Models/Inputs/ModifyReminderInput.swift
@@ -34,18 +34,19 @@ struct ModifyReminderInput {
         self.url = call.getString("url")
         self.location = call.getString("location")
         if let recurrence = call.getObject("recurrence") {
-            guard let frequencyString = recurrence["frequency"] as? String else {
+            guard recurrence["frequency"] != nil else {
                 throw PluginError.missingFrequency
             }
-            guard let frequency = RecurrenceInput.Frequency(rawValue: frequencyString) else {
+            guard let frequencyString = recurrence["frequency"] as? String,
+                  let frequency = RecurrenceInput.Frequency(rawValue: frequencyString) else {
                 throw PluginError.invalidFrequency
             }
             self.frequency = frequency.toEKFrequency()
-            guard let interval = recurrence["interval"] as? Int else {
+            guard let interval = ImplementationHelper.int(from: recurrence["interval"]) else {
                 throw PluginError.missingInterval
             }
             self.interval = interval
-            self.end = recurrence["end"] as? Double
+            self.end = ImplementationHelper.double(from: recurrence["end"])
         }
         self.alerts = call.getArray("alerts") as? [Double]
     }

--- a/ios/Plugin/Models/Inputs/ModifyReminderInput.swift
+++ b/ios/Plugin/Models/Inputs/ModifyReminderInput.swift
@@ -34,15 +34,18 @@ struct ModifyReminderInput {
         self.url = call.getString("url")
         self.location = call.getString("location")
         if let recurrence = call.getObject("recurrence") {
-            guard let frequency = recurrence["frequency"] as? Int else {
+            guard let frequencyString = recurrence["frequency"] as? String else {
                 throw PluginError.missingFrequency
             }
-            self.frequency = EKRecurrenceFrequency(rawValue: frequency)
+            guard let frequency = RecurrenceInput.Frequency(rawValue: frequencyString) else {
+                throw PluginError.invalidFrequency
+            }
+            self.frequency = frequency.toEKFrequency()
             guard let interval = recurrence["interval"] as? Int else {
                 throw PluginError.missingInterval
             }
             self.interval = interval
-            let end = recurrence["end"] as? Double
+            self.end = recurrence["end"] as? Double
         }
         self.alerts = call.getArray("alerts") as? [Double]
     }

--- a/ios/Plugin/Models/Structs/RecurrenceInput.swift
+++ b/ios/Plugin/Models/Structs/RecurrenceInput.swift
@@ -16,13 +16,13 @@ struct RecurrenceInput {
             }
         }
 
-        static func from(ekFrequency: EKRecurrenceFrequency) -> Frequency {
+        static func from(ekFrequency: EKRecurrenceFrequency) -> Frequency? {
             switch ekFrequency {
             case .daily: return .daily
             case .weekly: return .weekly
             case .monthly: return .monthly
             case .yearly: return .yearly
-            @unknown default: return .daily
+            @unknown default: return nil
             }
         }
     }

--- a/ios/Plugin/Models/Structs/RecurrenceInput.swift
+++ b/ios/Plugin/Models/Structs/RecurrenceInput.swift
@@ -15,6 +15,16 @@ struct RecurrenceInput {
             case .yearly: return .yearly
             }
         }
+
+        static func from(ekFrequency: EKRecurrenceFrequency) -> Frequency {
+            switch ekFrequency {
+            case .daily: return .daily
+            case .weekly: return .weekly
+            case .monthly: return .monthly
+            case .yearly: return .yearly
+            @unknown default: return .daily
+            }
+        }
     }
 
     let frequency: Frequency

--- a/ios/Plugin/PluginError.swift
+++ b/ios/Plugin/PluginError.swift
@@ -14,6 +14,7 @@ enum PluginError: LocalizedError {
     case fromDateMissing
     case idMissing
     case invalidColor
+    case invalidFrequency
     case invalidScope
     case invalidUrl
     case listIdsMissing
@@ -61,6 +62,8 @@ enum PluginError: LocalizedError {
             return NSLocalizedString("Event ID must be provided.", comment: "Event ID missing error")
         case .invalidColor:
             return NSLocalizedString("Invalid color format.", comment: "Invalid color format error")
+        case .invalidFrequency:
+            return NSLocalizedString("Invalid frequency.", comment: "Invalid frequency error")
         case .invalidScope:
             return NSLocalizedString("Invalid scope.", comment: "Invalid scope error")
         case .invalidUrl:

--- a/ios/Plugin/Utils/ImplementationHelper.swift
+++ b/ios/Plugin/Utils/ImplementationHelper.swift
@@ -240,12 +240,11 @@ struct ImplementationHelper {
         }
         rules.forEach { rule in
             var obj = JSObject()
-            obj["frequency"] = rule.frequency.rawValue
+            obj["frequency"] = RecurrenceInput.Frequency.from(ekFrequency: rule.frequency).rawValue
             obj["interval"] = rule.interval
-            if let recurrenceEnd = rule.recurrenceEnd {
-                obj["end"] = ImplementationHelper.dateToMillis(recurrenceEnd.endDate) ?? NSNull()
-            } else {
-                obj["end"] = NSNull()
+            if let recurrenceEnd = rule.recurrenceEnd,
+               let endMs = ImplementationHelper.dateToMillis(recurrenceEnd.endDate) {
+                obj["end"] = endMs
             }
             result.append(obj)
         }

--- a/ios/Plugin/Utils/ImplementationHelper.swift
+++ b/ios/Plugin/Utils/ImplementationHelper.swift
@@ -5,6 +5,24 @@ struct ImplementationHelper {
     /// Default calendar color when `color` is omitted: `#007AFF` (light-mode iOS system blue).
     static let defaultCalendarColorHex = "#007AFF"
 
+    /// Reads a JS number that may arrive as `Int`, `Double`, or `NSNumber`.
+    static func int(from value: Any?) -> Int? {
+        guard let value = value, !(value is NSNull) else { return nil }
+        if let number = value as? NSNumber { return number.intValue }
+        if let intValue = value as? Int { return intValue }
+        if let doubleValue = value as? Double { return Int(doubleValue) }
+        return nil
+    }
+
+    /// Reads a JS number that may arrive as `Int`, `Double`, or `NSNumber`.
+    static func double(from value: Any?) -> Double? {
+        guard let value = value, !(value is NSNull) else { return nil }
+        if let number = value as? NSNumber { return number.doubleValue }
+        if let doubleValue = value as? Double { return doubleValue }
+        if let intValue = value as? Int { return Double(intValue) }
+        return nil
+    }
+
     static func permissionStateToResult(state: EKAuthorizationStatus, scope: CalendarPermissionScope ) throws -> CAPPermissionState {
         var result: CAPPermissionState
 
@@ -239,8 +257,11 @@ struct ImplementationHelper {
             return result
         }
         rules.forEach { rule in
+            guard let frequency = RecurrenceInput.Frequency.from(ekFrequency: rule.frequency) else {
+                return
+            }
             var obj = JSObject()
-            obj["frequency"] = RecurrenceInput.Frequency.from(ekFrequency: rule.frequency).rawValue
+            obj["frequency"] = frequency.rawValue
             obj["interval"] = rule.interval
             if let recurrenceEnd = rule.recurrenceEnd,
                let endMs = ImplementationHelper.dateToMillis(recurrenceEnd.endDate) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebarooni/capacitor-calendar",
-  "version": "8.6.0",
+  "version": "8.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebarooni/capacitor-calendar",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebarooni/capacitor-calendar",
-  "version": "8.6.0",
+  "version": "8.7.0",
   "description": "A Capacitor plugin for managing calendar events on iOS, Android, and the web, with reminders support on iOS.",
   "author": "Ehsan Barooni",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import type { CreateEventResult } from './schemas/interfaces/create-event-result
 import type { CreateEventWithPromptOptions } from './schemas/interfaces/create-event-with-prompt-options';
 import type { CreateEventWithPromptResult } from './schemas/interfaces/create-event-with-prompt-result';
 import type { CreateReminderOptions } from './schemas/interfaces/create-reminder-options';
+import type { CreateReminderResult } from './schemas/interfaces/create-reminder-result';
 import type { CreateRemindersListOptions } from './schemas/interfaces/create-reminders-list-options';
 import type { CreateRemindersListResult } from './schemas/interfaces/create-reminders-list-result';
 import type { DeleteCalendarOptions } from './schemas/interfaces/delete-calendar-options';
@@ -32,12 +33,15 @@ import type { DeleteEventsByIdOptions } from './schemas/interfaces/delete-events
 import type { DeleteReminderOptions } from './schemas/interfaces/delete-reminder-options';
 import type { DeleteReminderWithPromptOptions } from './schemas/interfaces/delete-reminder-with-prompt-options';
 import type { DeleteRemindersByIdOptions } from './schemas/interfaces/delete-reminders-by-id-options';
+import type { DeleteRemindersByIdResult } from './schemas/interfaces/delete-reminders-by-id-result';
 import type { DeleteRemindersListOptions } from './schemas/interfaces/delete-reminders-list-options';
 import type { EventGuest } from './schemas/interfaces/event-guest';
 import type { FetchAllCalendarSourcesResult } from './schemas/interfaces/fetch-all-calendar-sources-result';
 import type { GetDefaultCalendarOptions } from './schemas/interfaces/get-default-calendar-options';
 import type { GetReminderByIdOptions } from './schemas/interfaces/get-reminder-by-id-options';
+import type { GetReminderByIdResult } from './schemas/interfaces/get-reminder-by-id-result';
 import type { GetRemindersFromListsOptions } from './schemas/interfaces/get-reminders-from-lists-options';
+import type { GetRemindersFromListsResult } from './schemas/interfaces/get-reminders-from-lists-result';
 import type { ListCalendarsResult } from './schemas/interfaces/list-calendars-result';
 import type { ListEventsInRangeOptions } from './schemas/interfaces/list-events-in-range-options';
 import type { ListEventsInRangeResult } from './schemas/interfaces/list-events-in-range-result';
@@ -59,7 +63,6 @@ import type { EventEditAction } from './schemas/types/event-edit-action';
 import type { RecurrenceFrequency } from './schemas/types/recurrence-frequency';
 import type { CheckAllPermissionsResult, RequestAllPermissionsResult } from './sub-definitions/calendar-access';
 import type { DeleteEventsByIdResult } from './sub-definitions/event-operations';
-import type { DeleteRemindersByIdResult } from './sub-definitions/reminders-operations';
 import { downloadIcsFile } from './web/download-ics-file';
 
 const CapacitorCalendar = registerPlugin<CapacitorCalendarPlugin>('CapacitorCalendar', {
@@ -80,6 +83,7 @@ export type {
   CreateEventWithPromptOptions,
   CreateEventWithPromptResult,
   CreateReminderOptions,
+  CreateReminderResult,
   CreateRemindersListOptions,
   CreateRemindersListResult,
   DeleteCalendarOptions,
@@ -97,7 +101,9 @@ export type {
   FetchAllCalendarSourcesResult,
   GetDefaultCalendarOptions,
   GetReminderByIdOptions,
+  GetReminderByIdResult,
   GetRemindersFromListsOptions,
+  GetRemindersFromListsResult,
   ListCalendarsResult,
   ListEventsInRangeOptions,
   ListEventsInRangeResult,

--- a/src/schemas/enums/reminder-recurrence-frequency.ts
+++ b/src/schemas/enums/reminder-recurrence-frequency.ts
@@ -1,21 +1,21 @@
 /**
- * @deprecated Use `RecurrenceFrequency`.
+ * @deprecated Use `'daily'`, `'weekly'`, `'monthly'`, or `'yearly'` (`RecurrenceFrequency`).
  */
 export enum ReminderRecurrenceFrequency {
   /**
-   * @deprecated Use `RecurrenceFrequency.DAILY`.
+   * @deprecated Use `'daily'`.
    */
   DAILY,
   /**
-   * @deprecated Use `RecurrenceFrequency.WEEKLY`.
+   * @deprecated Use `'weekly'`.
    */
   WEEKLY,
   /**
-   * @deprecated Use `RecurrenceFrequency.MONTHLY`.
+   * @deprecated Use `'monthly'`.
    */
   MONTHLY,
   /**
-   * @deprecated Use `RecurrenceFrequency.YEARLY`.
+   * @deprecated Use `'yearly'`.
    */
   YEARLY,
 }

--- a/src/schemas/interfaces/create-reminder-options.ts
+++ b/src/schemas/interfaces/create-reminder-options.ts
@@ -45,6 +45,7 @@ export interface CreateReminderOptions {
    */
   location?: string;
   /**
+   * @platform iOS
    * @since 7.1.0
    */
   recurrence?: RecurrenceRule;

--- a/src/schemas/interfaces/create-reminder-result.ts
+++ b/src/schemas/interfaces/create-reminder-result.ts
@@ -1,0 +1,12 @@
+/**
+ * @since 0.5.0
+ */
+export interface CreateReminderResult {
+  /**
+   * Identifier of the newly created reminder.
+   *
+   * @platform iOS
+   * @since 0.5.0
+   */
+  id: string;
+}

--- a/src/schemas/interfaces/delete-reminders-by-id-result.ts
+++ b/src/schemas/interfaces/delete-reminders-by-id-result.ts
@@ -1,0 +1,13 @@
+/**
+ * @since 7.1.0
+ */
+export interface DeleteRemindersByIdResult {
+  /**
+   * @since 7.1.0
+   */
+  deleted: string[];
+  /**
+   * @since 7.1.0
+   */
+  failed: string[];
+}

--- a/src/schemas/interfaces/get-reminder-by-id-result.ts
+++ b/src/schemas/interfaces/get-reminder-by-id-result.ts
@@ -1,0 +1,14 @@
+import type { Reminder } from './reminder';
+
+/**
+ * @since 7.1.0
+ */
+export interface GetReminderByIdResult {
+  /**
+   * The reminder for the given id, or `null` when none exists.
+   *
+   * @platform iOS
+   * @since 7.1.0
+   */
+  result: Reminder | null;
+}

--- a/src/schemas/interfaces/get-reminders-from-lists-result.ts
+++ b/src/schemas/interfaces/get-reminders-from-lists-result.ts
@@ -1,0 +1,14 @@
+import type { Reminder } from './reminder';
+
+/**
+ * @since 5.3.0
+ */
+export interface GetRemindersFromListsResult {
+  /**
+   * Reminders from the requested lists.
+   *
+   * @platform iOS
+   * @since 5.3.0
+   */
+  result: Reminder[];
+}

--- a/src/schemas/interfaces/modify-reminder-options.ts
+++ b/src/schemas/interfaces/modify-reminder-options.ts
@@ -49,6 +49,7 @@ export interface ModifyReminderOptions {
    */
   location?: string;
   /**
+   * @platform iOS
    * @since 7.1.0
    */
   recurrence?: RecurrenceRule;

--- a/src/schemas/interfaces/recurrence-rule.ts
+++ b/src/schemas/interfaces/recurrence-rule.ts
@@ -5,18 +5,24 @@ import type { RecurrenceFrequency } from '../types/recurrence-frequency';
  */
 export interface RecurrenceRule {
   /**
+   * How often the reminder repeats.
+   *
+   * @example 'weekly'
+   * @platform iOS
    * @since 7.1.0
    */
   frequency: RecurrenceFrequency;
   /**
    * How often it repeats (e.g. 1 for every occurrence, 2 for every second occurrence).
    *
+   * @platform iOS
    * @since 7.1.0
    */
   interval: number;
   /**
-   * Timestamp of when the recurrence ends.
+   * End of the recurrence series as a Unix timestamp in milliseconds.
    *
+   * @platform iOS
    * @since 7.1.0
    */
   end?: number;

--- a/src/schemas/interfaces/reminder.ts
+++ b/src/schemas/interfaces/reminder.ts
@@ -49,6 +49,7 @@ export interface Reminder {
    */
   completionDate: number | null;
   /**
+   * @platform iOS
    * @since 7.1.0
    */
   recurrence: RecurrenceRule[];

--- a/src/sub-definitions/reminders-operations.ts
+++ b/src/sub-definitions/reminders-operations.ts
@@ -1,15 +1,18 @@
 import type { CalendarSource } from '../schemas/interfaces/calendar-source';
 import type { CreateReminderOptions } from '../schemas/interfaces/create-reminder-options';
+import type { CreateReminderResult } from '../schemas/interfaces/create-reminder-result';
 import type { CreateRemindersListOptions } from '../schemas/interfaces/create-reminders-list-options';
 import type { CreateRemindersListResult } from '../schemas/interfaces/create-reminders-list-result';
 import type { DeleteReminderOptions } from '../schemas/interfaces/delete-reminder-options';
 import type { DeleteReminderWithPromptOptions } from '../schemas/interfaces/delete-reminder-with-prompt-options';
 import type { DeleteRemindersByIdOptions } from '../schemas/interfaces/delete-reminders-by-id-options';
+import type { DeleteRemindersByIdResult } from '../schemas/interfaces/delete-reminders-by-id-result';
 import type { DeleteRemindersListOptions } from '../schemas/interfaces/delete-reminders-list-options';
 import type { GetReminderByIdOptions } from '../schemas/interfaces/get-reminder-by-id-options';
+import type { GetReminderByIdResult } from '../schemas/interfaces/get-reminder-by-id-result';
 import type { GetRemindersFromListsOptions } from '../schemas/interfaces/get-reminders-from-lists-options';
+import type { GetRemindersFromListsResult } from '../schemas/interfaces/get-reminders-from-lists-result';
 import type { ModifyReminderOptions } from '../schemas/interfaces/modify-reminder-options';
-import type { Reminder } from '../schemas/interfaces/reminder';
 import type { RemindersList } from '../schemas/interfaces/reminders-list';
 import type { UpdateRemindersListOptions } from '../schemas/interfaces/update-reminders-list-options';
 import type { UpdateRemindersListResult } from '../schemas/interfaces/update-reminders-list-result';
@@ -64,7 +67,7 @@ export interface RemindersOperations {
    * @platform iOS
    * @since 0.5.0
    */
-  createReminder(options: CreateReminderOptions): Promise<{ id: string }>;
+  createReminder(options: CreateReminderOptions): Promise<CreateReminderResult>;
   /**
    * Deletes multiple reminders.
    *
@@ -93,14 +96,14 @@ export interface RemindersOperations {
    * @platform iOS
    * @since 7.1.0
    */
-  getReminderById(options: GetReminderByIdOptions): Promise<{ result: Reminder | null }>;
+  getReminderById(options: GetReminderByIdOptions): Promise<GetReminderByIdResult>;
   /**
    * Retrieves reminders from multiple lists.
    *
    * @platform iOS
    * @since 5.3.0
    */
-  getRemindersFromLists(options: GetRemindersFromListsOptions): Promise<{ result: Reminder[] }>;
+  getRemindersFromLists(options: GetRemindersFromListsOptions): Promise<GetRemindersFromListsResult>;
   /**
    * Opens a dialog to delete a reminder.
    *
@@ -115,18 +118,4 @@ export interface RemindersOperations {
    * @since 8.2.0
    */
   updateRemindersList(options: UpdateRemindersListOptions): Promise<UpdateRemindersListResult>;
-}
-
-/**
- * @since 7.1.0
- */
-export interface DeleteRemindersByIdResult {
-  /**
-   * @since 7.1.0
-   */
-  deleted: string[];
-  /**
-   * @since 7.1.0
-   */
-  failed: string[];
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -12,6 +12,7 @@ import type { CreateEventResult } from './schemas/interfaces/create-event-result
 import type { CreateEventWithPromptOptions } from './schemas/interfaces/create-event-with-prompt-options';
 import type { CreateEventWithPromptResult } from './schemas/interfaces/create-event-with-prompt-result';
 import type { CreateReminderOptions } from './schemas/interfaces/create-reminder-options';
+import type { CreateReminderResult } from './schemas/interfaces/create-reminder-result';
 import type { CreateRemindersListOptions } from './schemas/interfaces/create-reminders-list-options';
 import type { CreateRemindersListResult } from './schemas/interfaces/create-reminders-list-result';
 import type { DeleteCalendarOptions } from './schemas/interfaces/delete-calendar-options';
@@ -21,11 +22,14 @@ import type { DeleteEventsByIdOptions } from './schemas/interfaces/delete-events
 import type { DeleteReminderOptions } from './schemas/interfaces/delete-reminder-options';
 import type { DeleteReminderWithPromptOptions } from './schemas/interfaces/delete-reminder-with-prompt-options';
 import type { DeleteRemindersByIdOptions } from './schemas/interfaces/delete-reminders-by-id-options';
+import type { DeleteRemindersByIdResult } from './schemas/interfaces/delete-reminders-by-id-result';
 import type { DeleteRemindersListOptions } from './schemas/interfaces/delete-reminders-list-options';
 import type { FetchAllCalendarSourcesResult } from './schemas/interfaces/fetch-all-calendar-sources-result';
 import type { GetDefaultCalendarOptions } from './schemas/interfaces/get-default-calendar-options';
 import type { GetReminderByIdOptions } from './schemas/interfaces/get-reminder-by-id-options';
+import type { GetReminderByIdResult } from './schemas/interfaces/get-reminder-by-id-result';
 import type { GetRemindersFromListsOptions } from './schemas/interfaces/get-reminders-from-lists-options';
+import type { GetRemindersFromListsResult } from './schemas/interfaces/get-reminders-from-lists-result';
 import type { ListCalendarsResult } from './schemas/interfaces/list-calendars-result';
 import type { ListEventsInRangeOptions } from './schemas/interfaces/list-events-in-range-options';
 import type { ListEventsInRangeResult } from './schemas/interfaces/list-events-in-range-result';
@@ -34,7 +38,6 @@ import type { ModifyEventOptions } from './schemas/interfaces/modify-event-optio
 import type { ModifyEventWithPromptOptions } from './schemas/interfaces/modify-event-with-prompt-options';
 import type { ModifyReminderOptions } from './schemas/interfaces/modify-reminder-options';
 import type { OpenCalendarOptions } from './schemas/interfaces/open-calendar-options';
-import type { Reminder } from './schemas/interfaces/reminder';
 import type { RemindersList } from './schemas/interfaces/reminders-list';
 import type { RequestPermissionOptions } from './schemas/interfaces/request-permission-options';
 import type { SelectCalendarsWithPromptOptions } from './schemas/interfaces/select-calendars-with-prompt-options';
@@ -44,7 +47,6 @@ import type { UpdateRemindersListResult } from './schemas/interfaces/update-remi
 import type { EventEditAction } from './schemas/types/event-edit-action';
 import type { CheckAllPermissionsResult, RequestAllPermissionsResult } from './sub-definitions/calendar-access';
 import type { DeleteEventsByIdResult } from './sub-definitions/event-operations';
-import type { DeleteRemindersByIdResult } from './sub-definitions/reminders-operations';
 import { buildEventIcs, resolveIcsFileName } from './web/ics';
 
 export class CapacitorCalendarWeb extends WebPlugin implements CapacitorCalendarPlugin {
@@ -167,7 +169,7 @@ export class CapacitorCalendarWeb extends WebPlugin implements CapacitorCalendar
     return this.throwUnimplemented(this.deleteCalendar.name);
   }
 
-  public createReminder(_options: CreateReminderOptions): Promise<{ id: string }> {
+  public createReminder(_options: CreateReminderOptions): Promise<CreateReminderResult> {
     return this.throwUnimplemented(this.createReminder.name);
   }
 
@@ -183,11 +185,11 @@ export class CapacitorCalendarWeb extends WebPlugin implements CapacitorCalendar
     return this.throwUnimplemented(this.modifyReminder.name);
   }
 
-  public getReminderById(_options: GetReminderByIdOptions): Promise<{ result: Reminder | null }> {
+  public getReminderById(_options: GetReminderByIdOptions): Promise<GetReminderByIdResult> {
     return this.throwUnimplemented(this.getReminderById.name);
   }
 
-  public getRemindersFromLists(_options: GetRemindersFromListsOptions): Promise<{ result: Reminder[] }> {
+  public getRemindersFromLists(_options: GetRemindersFromListsOptions): Promise<GetRemindersFromListsResult> {
     return this.throwUnimplemented(this.getRemindersFromLists.name);
   }
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,5 @@
 {
   "entryPoints": ["src/index.ts"],
   "out": "typedoc-output",
-  "projectDocuments": ["mcp/README.md"]
+  "projectDocuments": ["mcp/README.md", "CHANGELOG.md", "BREAKING.md"]
 }


### PR DESCRIPTION
## Summary
- Fix iOS reminder recurrence so `end` is applied on create/modify; create, modify, and read use string `RecurrenceFrequency`; invalid/non-string frequencies reject with `Invalid frequency.`
- Harden JS number bridging for `interval` / `end`, skip unknown frequencies on read-back, and extract named reminder result interfaces
- Add `BREAKING.md` + 8.7.0 changelog/migration notes; demo create/modify/get reminder in the example app

Closes: #272

## Breaking change
`modifyReminder` and reminder read-back no longer use EventKit integer frequencies. Use `'daily' | 'weekly' | 'monthly' | 'yearly'`. See [BREAKING.md](https://github.com/ebarooni/capacitor-calendar/blob/fix/ios-reminder-recurrence/BREAKING.md).

## Test plan
- [ ] Create a reminder with `recurrence: { frequency: 'weekly', interval: 1, end: <timestamp> }` and confirm the series ends at that date
- [ ] Modify a reminder using string frequencies
- [ ] Read back via `getReminderById` / `getRemindersFromLists` — `frequency` is a string; `end` is omitted when unset
- [ ] Pass a numeric frequency (e.g. `0`) and confirm rejection with `Invalid frequency.`
- [ ] Exercise the new example-app reminder buttons on iOS